### PR TITLE
Currency: deprecated tooling notes (CrackMapExec→NetExec, twint)

### DIFF
--- a/ENHANCED_MASTER_GUIDE.md
+++ b/ENHANCED_MASTER_GUIDE.md
@@ -646,7 +646,7 @@ sherlock username
 # Maigret - enhanced username search
 maigret username
 
-# Twint - Twitter OSINT
+# Twint - Twitter OSINT (NOTE: archived/non-functional since X's 2023 API lockdown)
 twint -u username --timeline
 
 # Instagram loader

--- a/Tradecraft/active-directory.md
+++ b/Tradecraft/active-directory.md
@@ -239,6 +239,12 @@ crackmapexec smb 192.168.1.0/24 -u Administrator -H NTLM_HASH --sam   # Dump SAM
 crackmapexec smb 192.168.1.0/24 -u Administrator -H NTLM_HASH -x "whoami"
 ```
 
+> [!NOTE]
+> **CrackMapExec is deprecated.** The original project was archived in 2023 and
+> continues as **NetExec** (`nxc`) — a maintained drop-in replacement with the
+> same syntax (e.g. `nxc smb 192.168.1.0/24 -u Administrator -H NTLM_HASH`). The
+> `crackmapexec` commands in this guide work identically under `nxc`.
+
 ### Pass-the-Ticket (PtT)
 
 ```powershell

--- a/Tradecraft/osint-threat-intel.md
+++ b/Tradecraft/osint-threat-intel.md
@@ -419,6 +419,9 @@ to:@username
 #hashtag filter:media
  
 # OSINT tools
+# NOTE: twint and snscrape's Twitter/X modules broke with X's 2023 API lockdown
+# and are largely non-functional; current X collection generally requires the
+# official (paid) API or authenticated tooling.
 twint -u username --since 2023-01-01 --output tweets.csv --csv
 snscrape twitter-user username > tweets.json
  


### PR DESCRIPTION
Continued domain audit (verified 2026-07-30).

## Findings & changes
- **CrackMapExec → NetExec**: added a note in `Tradecraft/active-directory.md` that CME was archived in 2023 and continues as **NetExec (`nxc`)**, a drop-in replacement with identical syntax. Commands left as-is (they work under either name); README already cross-links both.
- **twint / snscrape**: noted in `Tradecraft/osint-threat-intel.md` and `ENHANCED_MASTER_GUIDE.md` that their Twitter/X modules broke with X's 2023 API lockdown and are largely non-functional.

## Clean pass (no changes needed)
- **SIEM guides** (ELK, Wazuh, Splunk, Graylog) audited and found current: modern `signed-by` keyrings (no `apt-key`), explicit/documented version pins (ELK 8.12, Graylog 5.2 + OpenSearch 2.12 with a "breaks on OpenSearch 3.0+" warning), security-on-by-default, and Splunk "do not hardcode a version" guidance. Well maintained.

## Deliberately left (viable / not errors)
- `sslstrip`, `dirbuster` (still shipped/educational), PowerShell **Empire** (actively maintained again by BC-Security), `wmic` (LOLBin).

Internal link check passes; no empty-link patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)