### PR TITLE
SDR/wireless audit: gr-gsm maintenance note

### DIFF
--- a/SDR/sdr.md
+++ b/SDR/sdr.md
@@ -1344,6 +1344,13 @@ rtl_433 -R 40 -f 433.92M  # Protocol 40 = LaCrosse weather station
 
 GSM uses TDMA on 900 MHz (GSM-900) and 1800 MHz (GSM-1800). Partially unencrypted control channels allow passive monitoring.
 
+> [!NOTE]
+> `gr-gsm` is no longer actively maintained upstream and does not build from
+> source against GNU Radio 3.10+ (an open PR tracks 3.10/3.11 support). The
+> Kali/Debian `apt` package below still works because it is built against the
+> distro's GNU Radio version; to build from source on a modern system, use a
+> community fork that adds 3.10 support.
+
 ```bash
 # gr-gsm: GNU Radio-based GSM receiver
 sudo apt install gr-gsm


### PR DESCRIPTION
SDR/wireless domain audit (verified 2026-07-30).

## Change
- **gr-gsm**: added a note at the install step that the project is unmaintained upstream and won't build from source against GNU Radio 3.10+ (open PR #600 tracks it); the Kali/Debian `apt` package still works, or use a community fork.

## Clean pass (no changes needed) — this domain is very well maintained
- **hashcat mode 22000** and **hcxpcapngtool** used throughout (not the old `-m 2500/16800` / `hcxpcaptool` / `cap2hccapx`)
- **Flipper Zero** firmware table correct: Official, Unleashed, **Momentum** (the renamed Xtreme, Next-Flip URLs), RogueMaster
- **Pwnagotchi** explicitly points to the maintained **jayofelony** fork and notes evilsocket's original is archived
- GQRX/SDR#/GNU Radio references valid; no version-pin problems

Internal link check passes; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)