### PR TITLE
Documentation + Hardware audit: Tor meek-azure note

### DIFF
--- a/Documentation/TOR.md
+++ b/Documentation/TOR.md
@@ -275,7 +275,7 @@ Use bridges when Tor is blocked or when you want to hide Tor usage from your ISP
 | ------------ | ------------------------------------------------ | ------------------------------- |
 | `obfs4`      | Obfuscates traffic to look random                | Most use cases, ISP blocking    |
 | `Snowflake`  | Routes through volunteer WebRTC proxies          | Heavy censorship (CN, IR, RU)   |
-| `meek-azure` | Disguises as Microsoft Azure traffic             | Very restrictive networks       |
+| `meek-azure` | Domain-fronting via Azure — **fronting largely deprecated**, slow; prefer WebTunnel/Snowflake | Last resort only               |
 | `WebTunnel`  | Mimics HTTPS to a website                        | Deep packet inspection bypass   |
 
 ### 5.2 Get Bridges


### PR DESCRIPTION
Documentation cheat sheets + Hardware domain audit (verified 2026-07-30).

## Change
- **Tor bridges** (`Documentation/TOR.md`): noted that meek-azure's Azure domain-fronting is largely deprecated/slow and to prefer WebTunnel/Snowflake. WebTunnel was already listed; obfs4/Snowflake current.

## Clean pass (no changes needed) — both domains well maintained
- **Cheat sheets** (Linux, ArchLinux, BlackArch): no `apt-key`, no `python2`/`SimpleHTTPServer`, no `youtube-dl`, no deprecated `egrep`/`fgrep`; AUR `yay`/`paru` install method current
- **Hardware**: `flashrom -p ch341a_spi` / `buspirate_spi` syntax correct; programmer docs (Bus Pirate, JTAGulator, T48/TL866, GreatFET) valid
- **Firmware guides**: Flipper (Momentum), Pwnagotchi (jayofelony), bjorn/evil_m5/bruce all current
- Tor Browser install via `torbrowser-launcher` valid; no v2 onion references

## Minor / broad (not changed)
- 13 `pip install` invocations across docs predate PEP 668 (`externally-managed-environment` on Kali/Debian 12+); works with `pipx`/venv/`--break-system-packages`. Repo-wide style choice, not a per-doc error — flagging rather than mass-editing.

Internal link check passes; markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)