### PR TITLE
Add Endpoint-Visibility and Digital-Forensics section READMEs

### DIFF
--- a/IncidentResponse/Digital-Forensics/README.md
+++ b/IncidentResponse/Digital-Forensics/README.md
@@ -1,0 +1,181 @@
+# 🔎 Digital Forensics (DFIR)
+
+<div align="center">
+
+**Post-incident artifact extraction and timeline reconstruction — memory, disk, and live response**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../../README.md) · [Incident Response](../README.md) section*
+
+![Blue Team](https://img.shields.io/badge/Operations-Blue_Team-blue?style=for-the-badge)
+![DFIR](https://img.shields.io/badge/Framework-DFIR-darkred?style=for-the-badge)
+![Forensics](https://img.shields.io/badge/Focus-Artifact_Analysis-purple?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Index for the Digital Forensics sub-section — guides for acquiring and analyzing evidence after an incident: memory forensics, disk forensics, and volatile live-response collection.
+
+## ⚙️ Function
+Links to a guide per forensic domain — memory analysis with Volatility 3, disk acquisition/analysis with Autopsy and KAPE, and live volatile-data collection — organized around the order of volatility and sound evidence handling.
+
+## 🏆 Goal
+Enable a responder to capture the right evidence in the right order, analyze it to establish a timeline and indicators of compromise (IoCs), and do so without destroying the evidentiary value of what they collect.
+
+## 📋 When to Use
+- Investigating a compromised host after detection (see [Endpoint Visibility](../Endpoint-Visibility/README.md) / [SIEM](../SIEM/README.md) alerts)
+- Deciding **what to collect first** from a running system before power-down
+- Extracting malware, injected code, or IoCs from a memory image
+- Building an incident timeline from disk artifacts (registry, event logs, prefetch)
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Forensic Domains](#forensic-domains)
+- [Analysis Guides](#analysis-guides)
+- [Order of Volatility](#order-of-volatility)
+- [⚠️ Evidence Handling & Legal Warning](#️-evidence-handling--legal-warning)
+- [Contributing](#contributing)
+- [Resources](#resources)
+
+---
+
+## 🎯 Overview
+
+**Digital forensics** is the disciplined recovery and analysis of evidence from computer systems. In an IR context it answers *what happened, how, when, and what was affected* — and, when a case may involve legal action, it does so in a way that preserves the evidence's admissibility.
+
+This sub-section covers the three domains you will use most: **memory**, **disk**, and **live volatile data**. Capture is governed by the *order of volatility* — the most transient evidence (RAM, network state) must be collected before it is lost.
+
+> [!CAUTION]
+> The act of investigating changes the system. Collect volatile evidence
+> **before** shutting down, prefer read-only/write-blocked access to disks, and
+> document every step. If a case may go to court, follow strict chain of custody.
+
+---
+
+## 🗂️ Forensic Domains
+
+| Domain | Guide | Evidence | Primary Tools |
+|--------|-------|----------|---------------|
+| 🧠 **Memory** | **[Memory/volatility_cheatsheet.md](./Memory/volatility_cheatsheet.md)** | RAM dump (volatile) | Volatility 3 |
+| 🚨 **Live Response** | **[LiveData/live_data_collection.md](./LiveData/live_data_collection.md)** | Running-system state | WinPmem, DumpIt, avml |
+| 💽 **Disk** | **[Disks/autopsy_kape.md](./Disks/autopsy_kape.md)** | Disk image (non-volatile) | Autopsy, KAPE, FTK Imager |
+
+---
+
+## 📚 Analysis Guides
+
+### 🧠 [Memory Forensics — Volatility 3](./Memory/volatility_cheatsheet.md)
+The full analysis workflow for Windows and Linux memory dumps. Covers the Volatility 3 plugin taxonomy (`windows.pslist`, `windows.cmdline`, `windows.netscan`, `windows.malfind`, `windows.dlllist`), process and network-connection analysis, injected-code detection, registry-hive extraction, and artifact recovery — the fastest route to malware and IoCs that never touch disk.
+
+### 🚨 [Live Response Collection](./LiveData/live_data_collection.md)
+Capturing **volatile** evidence from a running system before power-down. Covers the volatile-data priority order, memory acquisition (WinPmem, DumpIt, `avml` on Linux), network state (`netstat`/`ss`, active connections), process listing with hash verification, prefetch/amcache, registry-hive export, browser artifacts, and chain-of-custody documentation.
+
+### 💽 [Disk Forensics — Autopsy & KAPE](./Disks/autopsy_kape.md)
+Acquiring and analyzing disk images. Covers imaging (FTK Imager, `dd`), the Autopsy case workflow (full forensic platform), **KAPE** targets/modules for rapid triage collection, timeline analysis, file carving, hash verification, and report generation.
+
+---
+
+## 🧭 Order of Volatility
+
+```text
+Collect most-volatile first (adapted from RFC 3227):
+
+1. CPU registers, cache
+2. RAM (memory dump)  ........... Live Response + Memory guides
+3. Network state, running processes, open connections
+4. Temp files, swap/pagefile
+5. Disk (image it)  ............. Disk Forensics guide
+6. Remote logs / monitoring data
+7. Physical config, archival media
+```
+
+> [!TIP]
+> Detection usually comes from the [SIEM](../SIEM/README.md) or
+> [endpoint telemetry](../Endpoint-Visibility/README.md); forensics is what you
+> do **after** an alert to confirm, scope, and reconstruct the incident.
+
+---
+
+## ⚠️ Evidence Handling & Legal Warning
+
+```text
+═══════════════════════════════════════════════════════════════
+                 ⚠️  PRESERVE EVIDENTIARY VALUE  ⚠️
+═══════════════════════════════════════════════════════════════
+
+1. CHAIN OF CUSTODY
+   ► If the case may involve law enforcement or litigation, follow strict
+     Chain of Custody: document who, what, when, where for every item.
+   ► Use write-blockers for disk imaging; verify with hashes (MD5+SHA-256).
+   ► Mishandling can render evidence inadmissible.
+
+2. MINIMIZE FOOTPRINT
+   ► Investigating alters the system. Prefer trusted, statically-linked tools
+     run from external media; avoid tools that overwrite volatile memory.
+
+3. AUTHORIZATION & PRIVACY
+   ► Only analyze systems you own or are explicitly authorized (in writing) to
+     examine. Forensic access to others' systems can be unlawful.
+   ► Images/memory contain PII/credentials — store encrypted, share sanitized.
+
+4. MALWARE SAFETY
+   ► Analyze recovered malware only in isolated, host-only environments.
+   ► Do not upload targeted/proprietary samples to public sandboxes — it can
+     tip off the attacker.
+═══════════════════════════════════════════════════════════════
+```
+
+---
+
+## 🤝 Contributing
+
+Contributions from DFIR analysts are welcome.
+
+**What we accept:**
+- ✅ Volatility plugin recipes and analysis walkthroughs
+- ✅ KAPE targets/modules and Autopsy workflow tips
+- ✅ Live-response scripts (with volatility-order rationale)
+- ✅ Artifact-location references (registry persistence, browser paths)
+
+**Guidelines:**
+1. Sanitize any sample artifacts of real PII/credentials.
+2. Note tool **versions** (e.g., Volatility 3.x).
+3. Describe the investigative value in your PR.
+
+---
+
+## 📚 Resources
+
+- **Volatility 3:** <https://github.com/volatilityfoundation/volatility3>
+- **KAPE (Kroll):** <https://www.kroll.com/kape>
+- **Autopsy / The Sleuth Kit:** <https://www.autopsy.com/>
+- **RFC 3227 — Evidence Collection & Archiving:** <https://www.rfc-editor.org/rfc/rfc3227>
+- **The DFIR Report (real-world timelines):** <https://thedfirreport.com/>
+- **SANS DFIR posters & cheat sheets:** <https://www.sans.org/posters/>
+
+---
+
+## 🔗 Quick Links
+
+- [⬅️ Incident Response section](../README.md)
+- [👁️ Endpoint Visibility](../Endpoint-Visibility/README.md)
+- [📊 SIEM deployment guides](../SIEM/README.md)
+- [📖 Glossary](../../GLOSSARY.md) (DFIR, IoC, chain of custody…)
+- [🏠 Main Repository](../../README.md)
+
+---
+
+<div align="center">
+
+**🛡️ Collect carefully, document everything — evidence handled wrong is evidence lost.**
+
+*Maintained by [Pacific Northwest Computers (PNWC)](https://github.com/Pnwcomputers)*
+
+</div>
+
+---
+[⬅️ Back to Master Index](../../README.md) | [🎯 Role Navigation](../../START_HERE.md) | [Legal Notice](../../LEGAL.md)

--- a/IncidentResponse/Endpoint-Visibility/README.md
+++ b/IncidentResponse/Endpoint-Visibility/README.md
@@ -1,0 +1,170 @@
+# 👁️ Endpoint Visibility (EDR / Telemetry)
+
+<div align="center">
+
+**Host-level instrumentation — turn endpoints into rich telemetry sources for detection and hunting**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../../README.md) · [Incident Response](../README.md) section*
+
+![Blue Team](https://img.shields.io/badge/Operations-Blue_Team-blue?style=for-the-badge)
+![Telemetry](https://img.shields.io/badge/Focus-Endpoint_Telemetry-orange?style=for-the-badge)
+![Windows | Linux](https://img.shields.io/badge/Platforms-Windows_%7C_Linux-green?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Index for the Endpoint Visibility sub-section — deployment and configuration guides for the host-level instrumentation that feeds a SIEM: Windows Sysmon, Linux auditd/syslog, and cross-platform Osquery.
+
+## ⚙️ Function
+Links to a guide per instrumentation source — installation, configuration, the key events/queries that matter for detection, and how to forward the resulting telemetry into a SIEM.
+
+## 🏆 Goal
+Enable a defender to instrument Windows and Linux hosts so that process, network, file, and authentication activity is captured with enough fidelity to detect and reconstruct an attack.
+
+## 📋 When to Use
+- Standing up endpoint telemetry before (or alongside) a [SIEM](../SIEM/README.md)
+- Deciding what to log on Windows (Sysmon) vs Linux (auditd) hosts
+- Adding SQL-based, on-demand host inspection with Osquery for threat hunting
+- Tuning event volume so detections fire without drowning the SIEM in noise
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#overview)
+- [Instrumentation Sources](#instrumentation-sources)
+- [Deployment Guides](#deployment-guides)
+- [Deployment Workflow](#deployment-workflow)
+- [⚠️ Monitoring, Consent & Legal Warning](#️-monitoring-consent--legal-warning)
+- [Contributing](#contributing)
+- [Resources](#resources)
+
+---
+
+## 🎯 Overview
+
+A SIEM is only as good as the telemetry it ingests. **Endpoint visibility** is the practice of instrumenting hosts so that security-relevant activity — process creation, network connections, file writes, image loads, logons — is recorded in a form you can search and alert on.
+
+This sub-section covers the three sources that do most of the heavy lifting in a homelab or small SOC. They are complementary: Sysmon and auditd provide **continuous event streams**, while Osquery provides **on-demand, point-in-time inspection** of host state.
+
+> [!TIP]
+> Deploy an event stream first (Sysmon on Windows, auditd on Linux), forward it
+> to your [SIEM](../SIEM/README.md), then layer Osquery on top for interactive
+> hunting.
+
+---
+
+## 🗂️ Instrumentation Sources
+
+| Source | Guide | Platform | Model | Best For |
+|--------|-------|----------|-------|----------|
+| 🪟 **Sysmon** | **[Windows/sysmon.md](./Windows/sysmon.md)** | Windows | Continuous event stream | Rich process/network/file/DNS tracing |
+| 🐧 **Auditd / Syslog** | **[Linux/auditd_syslog.md](./Linux/auditd_syslog.md)** | Linux | Continuous event stream | Kernel-level syscall & file/session auditing |
+| 🔎 **Osquery** | **[Linux/osquery.md](./Linux/osquery.md)** | Cross-platform | On-demand SQL queries | Interactive threat hunting & host state |
+
+---
+
+## 📚 Deployment Guides
+
+### 🪟 [Windows Sysmon](./Windows/sysmon.md)
+Deploy and configure **Sysmon** with community configs (SwiftOnSecurity, Olaf Hartong). Covers install/update, the configuration XML structure, and the critical event IDs — **1** (process create), **3** (network), **7** (image load), **8** (CreateRemoteThread), **10** (process access), **11** (file create), **22** (DNS) — plus hashing, SIEM forwarding, and a detection use case per event type. The single highest-value Windows telemetry source.
+
+### 🐧 [Linux Auditd & Syslog](./Linux/auditd_syslog.md)
+Harden Linux logging with **auditd** and **rsyslog/syslog-ng**. Covers auditd rule syntax (syscall auditing, file-access watches, user-session tracking), pre-built rule sets (STIG, CIS), log forwarding to a SIEM, parsing with `ausearch`/`aureport`, and common detection use cases.
+
+### 🔎 [Osquery](./Linux/osquery.md)
+Instrument hosts as a **SQL-queryable** surface. Covers installation (with the modern `signed-by` apt keyring), configuration, and queries for proactive threat hunting and monitoring — ideal for asking ad-hoc questions ("which processes have a deleted binary on disk?") across a fleet.
+
+---
+
+## 🚀 Deployment Workflow
+
+```text
+1. Instrument
+   └─> Windows: install Sysmon with a curated config (Olaf Hartong / SwiftOnSecurity).
+   └─> Linux:   load an auditd rule set (CIS/STIG) + configure rsyslog forwarding.
+
+2. Forward
+   └─> Ship events to your SIEM (Winlogbeat/Filebeat, or the SIEM's own agent).
+   └─> Confirm events index correctly — see ../SIEM/README.md.
+
+3. Hunt on demand
+   └─> Add Osquery for interactive, SQL-based host inspection.
+
+4. Tune
+   └─> Trim noisy events; keep the high-signal IDs. Map detections to MITRE ATT&CK.
+```
+
+---
+
+## ⚠️ Monitoring, Consent & Legal Warning
+
+```text
+═══════════════════════════════════════════════════════════════
+              ⚠️  DEPLOY TELEMETRY ONLY WITH AUTHORIZATION  ⚠️
+═══════════════════════════════════════════════════════════════
+
+► Only install agents/telemetry on systems you own or are explicitly
+  authorized (in writing) to monitor. Endpoint monitoring can capture
+  keystrokes, commands, and personal data.
+
+► Covert monitoring of users/employees without proper notice can violate
+  wiretap/interception, privacy, and labor laws — coordinate with legal/HR.
+
+► Forwarded logs often contain PII/credentials; protect the SIEM and
+  transport (TLS) accordingly, and follow GDPR/HIPAA/CCPA where applicable.
+═══════════════════════════════════════════════════════════════
+```
+
+---
+
+## 🤝 Contributing
+
+Contributions from detection engineers and SOC analysts are welcome.
+
+**What we accept:**
+- ✅ Sysmon config tweaks and per-event-ID detection notes
+- ✅ auditd rule sets and rsyslog/syslog-ng forwarding configs
+- ✅ Useful Osquery packs/queries for hunting
+- ✅ SIEM field-mapping notes
+
+**Guidelines:**
+1. Sanitize sample events of real PII/credentials.
+2. Note the OS/tool **version** tested.
+3. Describe the detection value in your PR.
+
+---
+
+## 📚 Resources
+
+- **Sysmon (Sysinternals):** <https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon>
+- **sysmon-modular (Olaf Hartong):** <https://github.com/olafhartong/sysmon-modular>
+- **auditd / Linux Audit:** <https://github.com/linux-audit/audit-documentation/wiki>
+- **Osquery docs:** <https://osquery.readthedocs.io/>
+- **MITRE ATT&CK (data sources):** <https://attack.mitre.org/datasources/>
+
+---
+
+## 🔗 Quick Links
+
+- [⬅️ Incident Response section](../README.md)
+- [📊 SIEM deployment guides](../SIEM/README.md)
+- [🔎 Digital Forensics](../Digital-Forensics/README.md)
+- [📥 Log Aggregation primer](../log_agg.md)
+- [📖 Glossary](../../GLOSSARY.md) (EDR, IoC, TTP, Sysmon…)
+- [🏠 Main Repository](../../README.md)
+
+---
+
+<div align="center">
+
+**🛡️ Visibility is the foundation of defense — instrument hosts ethically and legally.**
+
+*Maintained by [Pacific Northwest Computers (PNWC)](https://github.com/Pnwcomputers)*
+
+</div>
+
+---
+[⬅️ Back to Master Index](../../README.md) | [🎯 Role Navigation](../../START_HERE.md) | [Legal Notice](../../LEGAL.md)


### PR DESCRIPTION
Adds folder-level index READMEs for the two remaining IncidentResponse sub-sections, matching the house style of the SIEM README (#18) and other sections.

## `IncidentResponse/Endpoint-Visibility/README.md`
Indexes the three telemetry sources with a comparison table and per-guide summaries:
- 🪟 **Sysmon** (Windows) — continuous event stream
- 🐧 **auditd/syslog** (Linux) — kernel-level auditing
- 🔎 **Osquery** (cross-platform) — on-demand SQL queries

Plus a telemetry→SIEM workflow and a monitoring/consent legal note.

## `IncidentResponse/Digital-Forensics/README.md`
Indexes the three forensic domains:
- 🧠 **Memory** — Volatility 3
- 🚨 **Live Response** — WinPmem/DumpIt/avml
- 💽 **Disk** — Autopsy/KAPE/FTK Imager

Plus an **order-of-volatility** guide (RFC 3227) and a chain-of-custody / evidence-handling warning.

## Notes
- Both cross-link each other and the SIEM index; give the parent IR README's directory links real landing pages.
- Content summaries drawn directly from each guide.
- Local markdownlint/link verification was blocked by a transient safety check this session, so **CI is the authoritative check** — both use the same house-style structure as the already-passing SIEM README, and all link targets were confirmed to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)