### PR TITLE
fix(F-05): upgrade external links to HTTPS where supported (F-06 reviewed)

### DIFF
--- a/HardwareHacking/LA1010.md
+++ b/HardwareHacking/LA1010.md
@@ -20,7 +20,7 @@ The Innomaker LA1010 is a high-performance USB logic analyzer with up to 100MHz 
 
 ## 🔗 Reference Links
 * **Product Link:** [Innomaker LA1010 on Amazon](https://www.amazon.com/dp/B07D21GG6J)
-* **Software:** [KingstVIS Download](http://www.qdkingst.com/en/download)
+* **Software:** [KingstVIS Download](https://www.qdkingst.com/en/download)
 
 ## 🚀 Step-by-Step Example: Setup, Connect, and Use
 **Scenario: Sniffing SPI traffic between a microcontroller and a radio module.**

--- a/SDR/README.md
+++ b/SDR/README.md
@@ -114,7 +114,7 @@ the Wiretap Act and ECPA.
 | **[Universal Radio Hacker (URH)](https://github.com/jopohl/urh)** | Protocol investigation, demodulation, and bit extraction | 🟡 MEDIUM |
 | **[Inspectrum](https://github.com/miek/inspectrum)** | Visual analysis of captured I/Q baseband signals | 🟢 LOW |
 | **[GNU Radio](https://www.gnuradio.org/)** | Block-based visual programming for DSP and signal routing | 🟡 MEDIUM |
-| **[Baudline](http://www.baudline.com/)** | Time-frequency signal analysis | 🟢 LOW |
+| **[Baudline](https://www.baudline.com/)** | Time-frequency signal analysis | 🟢 LOW |
 
 ---
 
@@ -324,7 +324,7 @@ We welcome contributions from RF researchers and security professionals, but all
 ### Licensing & Legal
 
 - **FCC Part 15 Rules**: [Understanding Unlicensed RF](https://www.fcc.gov/oet/ea/rfdevice)
-- **ARRL**: [Get your Amateur Radio (HAM) License](http://www.arrl.org/getting-licensed) (Highly recommended for SDR practitioners)
+- **ARRL**: [Get your Amateur Radio (HAM) License](https://www.arrl.org/getting-licensed) (Highly recommended for SDR practitioners)
 
 ### Learning SDR
 

--- a/SPECIALIZED_TOPICS_GUIDE.md
+++ b/SPECIALIZED_TOPICS_GUIDE.md
@@ -2418,7 +2418,7 @@ A HAM license enables legal transmission on many useful research frequencies:
 
 **Recommended:** Get at minimum a Technician license before transmitting with SDR hardware.
 
-Study resources: [ARRL.org](http://www.arrl.org/getting-licensed) · HamStudy.org · Ham Radio Prep app
+Study resources: [ARRL.org](https://www.arrl.org/getting-licensed) · HamStudy.org · Ham Radio Prep app
 
 [Return to Table of Contents](#table-of-contents)
 


### PR DESCRIPTION
Addresses **F-05** and **F-06** from `AUDIT_FINDINGS.md` (PR #23).

## F-05 — HTTPS upgrades

Each host was tested with `curl` before changing anything. Upgraded the three that actually serve HTTPS:

| Host | HTTPS result | Action |
|------|--------------|--------|
| `www.arrl.org` (×2) | 200 | → https |
| `www.qdkingst.com` | 200 | → https |
| `www.baudline.com` | 200 | → https |
| `dangerousprototypes.com` (×2) | TLS cert name mismatch | **left http://** |
| `www.xgecu.com` | HTTPS times out (HTTP 200) | **left http://** |
| `spyonweb.com` | unreachable both schemes | **left http://** |

## F-06 — reviewed, no changes

All 9 `TODO`/placeholder/`xxx` matches are **intentional** and were left untouched:

- `CWE-XXX` — fill-in field in a playbook **template**
- `PHPSESSID=xxx`, `45.142.213.xxx` — redacted example values
- `"""Placeholder for actual transmission"""` — deliberate **safety** placeholder (no working TX code)
- code-example annotations in `Phone_OSINT.md` / `sdr_hacking.md`
- "TODO Tree" — the name of a VS Code extension

Sterilizing example scripts is explicitly out of scope, so no edits were made here.

Verification: `markdownlint-cli2` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)