### PR TITLE
fix(F-02/F-03): link orphaned wireless-lab playbook; verify index coverage

### DIFF
--- a/Homelab/README.md
+++ b/Homelab/README.md
@@ -89,6 +89,7 @@ The routing, switching, and boundary protection of the lab.
 |-------------|------------|-------------|
 | **[Lab Setup & Maintenance](./HomeLab_Setup.md)** | Architecture | Core procedures for architecting, deploying, and maintaining homelab environments. |
 | **[Provisioning Workflows](./workflows/)** | Automation | Step-by-step guides for deployment workflows (Ansible/Terraform) and automation playbooks. |
+| **[Wireless Lab Security Assessment](./workflows/self-hosted_network_attacks.md)** | Offensive Testing | Master playbook for authorized security assessment of a self-hosted wireless lab. |
 | **Incident Response** | Blue Team | SOPs for log ingestion (ELK/Splunk) and artifact analysis within the lab environment. |
 | **Hardware Prep** | Physical Assets | OS installation, firmware flashing, and setup of physical pentest tools (e.g., Proxmark3). |
 


### PR DESCRIPTION
Addresses **F-02** and **F-03** from `AUDIT_FINDINGS.md` (PR #23).

## F-03 — real orphan fixed

`Homelab/workflows/self-hosted_network_attacks.md` was reachable only through a directory link labelled **"Provisioning Workflows (Ansible/Terraform)"** — which mislabels an offensive assessment playbook. Added a direct, correctly-labelled row so it's discoverable and accurately described.

## F-02 — intentionally not acted on (with rationale)

On inspection, all 9 directories flagged as "missing a README index" **already have every file linked or listed from their parent section README**:

- `Digital-Forensics/README` and `Endpoint-Visibility/README` link every leaf file
- `OSINT/README` links `scripts/*`; `Mobile/README` links `OnePlus_A3006/*`; `Scripts/README` links the Bash cheat-sheet

Adding per-directory index READMEs would duplicate those and is the filler the audit brief explicitly forbids. **If you'd prefer folder-level index stubs anyway** (so landing directly in a subfolder shows context instead of a bare file list), say so and I'll add concise ones — it's a house-style preference, not a correctness issue.

Remaining scanner "orphans" are non-issues: `.github/*` templates are unlinked by design; `Documentation/references.md` is table-listed in `Documentation/README` in the same backtick style as its siblings; `Scripts/GO/shells/README.md` sits under the root-linked `Scripts/GO` directory.

Verification: target exists, orphan scan clears the Homelab file, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)