### PR TITLE
fix(F-10): repair dead/retired external links (scope 10 online sweep)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -42,6 +42,7 @@ source; **Medium** = verified pattern but individual instances need a human call
 | F-07 | Editorial | Structure | Very large monolithic guides are candidates for splitting | 4 docs | Low | ⏸️ Deferred by owner |
 | F-08 | Medium | Duplication | Core topics duplicated across several root "master guide" docs with no canonical source | 6+ topics | High | 🔵 Open — plan in report |
 | F-09 | Medium | Safety | Inconsistent prominence of the safety/authorization header on offensive docs | ~3 docs | Medium | 🔵 Open — plan in report |
+| F-10 | Low | Link hygiene | Dead/retired external links (scope 10, online sweep) | 4 fixed, 4 flagged | High | ✅ Fixed dead links; 4 flagged for manual review |
 
 *Findings F-08–F-09 come from the second audit pass (scope 2/4/11). The
 remediation approach for both lives in [AUDIT_REPORT.md](./AUDIT_REPORT.md)
@@ -290,6 +291,33 @@ each fix should be visually confirmed in GitHub's preview.*
   `STYLE_GUIDE.md` and apply it near the top of each offensive doc.
 - **Proposed action:** add the standard to the style guide, then apply per doc.
   This **adds** warnings/context; it removes nothing.
+
+---
+
+## F-10 — Dead / retired external links (scope 10, online sweep)
+
+- **Priority:** Low **Category:** Link hygiene **Confidence:** High **Status:** ✅ Dead links fixed; 4 flagged for manual review
+- **Method:** full online link sweep (lychee) over all tracked Markdown, then every
+  failure re-verified by hand (browser user-agent + DNS check) to separate truly
+  dead domains from bot-blocking / transient timeouts. Of ~2040 unique links,
+  most "errors" were bot-blocks; the following were confirmed.
+- **Fixed — confirmed dead or retired, repointed to verified successors:**
+  - `farsightsecurity.com` (NXDOMAIN — Farsight acquired by DomainTools 2021) →
+    DomainTools DNSDB. `OSINT/OSINT_TOOLS_CATALOG.md`
+  - `community.riskiq.com` (RiskIQ acquired by Microsoft; portal retired) →
+    Microsoft Defender Threat Intelligence. `OSINT_TOOLS_CATALOG.md`,
+    `Tradecraft/osint-threat-intel.md`
+  - `onion.link` (Tor2web deprecated 2019, gateway defunct) → Ahmia.
+    `OSINT_TOOLS_CATALOG.md`
+  - `zonefiles.io` (NXDOMAIN) → entry kept, dead link removed, alternatives noted
+    (WhoisXML API / Whoisds). `OSINT_TOOLS_CATALOG.md`
+- **Flagged for manual review — host resolves but blocked automated checks (likely
+  fine for humans; NOT changed to avoid breaking working links):**
+  `abusix.org` (connection reset — WAF), `emailcrawlr.com` (TLS eof),
+  `threatjammer.com` (connection reset), `got-hacked.wtf` (serves a default
+  "Plesk" TLS cert — genuinely misconfigured HTTPS, worth a look).
+- **Note:** `qdkingst.com` failed in the automated sweep but verified **working**
+  by hand — no action (the F-05 HTTPS upgrade stands).
 
 ---
 

--- a/OSINT/OSINT_TOOLS_CATALOG.md
+++ b/OSINT/OSINT_TOOLS_CATALOG.md
@@ -62,12 +62,12 @@ Third-party services mainline SpiderFoot (`smicallef/spiderfoot`) can query on a
 
 ### 2. DNS, DOMAIN, WHOIS & CERTIFICATES
 * [**SecurityTrails**](https://securitytrails.com/): Obtain Passive DNS and other information from SecurityTrails. *(Free tier · key)*
-* [**DNSDB**](https://www.farsightsecurity.com): Query FarSight's DNSDB for historical and passive DNS data. *(Free tier · key)*
+* [**DNSDB**](https://www.domaintools.com/products/farsight-dnsdb/): Query Farsight DNSDB for historical and passive DNS data. *(Farsight Security was acquired by DomainTools in 2021; the old farsightsecurity.com domain no longer resolves.)* *(Free tier · key)*
 * [**CIRCL.LU**](https://www.circl.lu/): Obtain information from CIRCL.LU's Passive DNS and Passive SSL databases. *(Free · key)*
-* [**RiskIQ**](https://community.riskiq.com/): Obtain information from RiskIQ's (formerly PassiveTotal) Passive DNS and Passive SSL databases. *(Free tier · key)*
+* [**Microsoft Defender Threat Intelligence**](https://ti.defender.microsoft.com/): Passive DNS and Passive SSL data formerly served by RiskIQ / PassiveTotal. *(RiskIQ was acquired by Microsoft in 2021; the community.riskiq.com portal was retired and its data folded into Defender TI.)* *(Paid · key)*
 * [**Host.io**](https://host.io): Obtain information about domain names from host.io. *(Free tier · key)*
 * [**Zetalytics**](https://zetalytics.com/): Query the Zetalytics database for hosts on your target domain(s). *(Free tier · key)*
-* [**ZoneFile.io**](https://zonefiles.io): Search ZoneFiles.io Domain query API for domain information. *(Free tier · key)*
+* **ZoneFile.io**: Domain zone-file query API. *(⚠️ Service appears defunct as of 2026-08 — zonefiles.io no longer resolves. For bulk zone-file / newly-registered-domain data, consider [WhoisXML API](https://www.whoisxmlapi.com/) or [Whoisds](https://whoisds.com/newly-registered-domains) instead.)*
 * [**CertSpotter**](https://sslmate.com/certspotter/): Gather information about SSL certificates from SSLMate CertSpotter API. *(Free tier · key)*
 * [**ViewDNS.info**](https://viewdns.info/): Identify co-hosted websites and perform reverse Whois lookups using ViewDNS.info. *(Free tier · key)*
 * [**JsonWHOIS.com**](https://jsonwhois.com): Search JsonWHOIS.com for WHOIS records associated with a domain. *(Free tier · key)*
@@ -131,7 +131,7 @@ Third-party services mainline SpiderFoot (`smicallef/spiderfoot`) can query on a
 * [**Google**](https://developers.google.com/custom-search): Obtain information from the Google Custom Search API to identify sub-domains and links. *(Free tier · key)*
 * [**OpenCorporates**](https://opencorporates.com): Look up company information from OpenCorporates. *(Free · key optional)*
 * [**StackOverflow**](https://www.stackexchange.com): Search StackOverflow for any mentions of a target domain. Returns potentially related information. *(Free · key optional)*
-* [**Onion.link**](https://onion.link/): Search Tor 'Onion City' search engine for mentions of the target domain using Google Custom Search. *(Free · key optional)*
+* [**Ahmia**](https://ahmia.fi/): Search the Tor network for onion services mentioning the target. *(Replaces the defunct Onion.link / "Onion City" Tor2web gateway — most Tor2web services shut down after the Tor Project deprecated Tor2web in 2019.)* *(Free)*
 
 ### 7. PHONE NUMBER INTELLIGENCE
 * [**numverify**](https://numverify.com/): Lookup phone number location and carrier information from numverify.com. *(Free tier · key)*

--- a/Tradecraft/osint-threat-intel.md
+++ b/Tradecraft/osint-threat-intel.md
@@ -231,7 +231,7 @@ dig axfr target.com @ns1.target.com
 # DNS history (passive)
 securitytrails.com
 passivedns.mnemonic.no
-community.riskiq.com (PassiveTotal)
+ti.defender.microsoft.com (PassiveTotal/RiskIQ retired -> Microsoft Defender TI)
 ```
  
 ### ASN & IP Range Mapping


### PR DESCRIPTION
Continues the audit with **scope 10 (external-link validation)** — the part CI only ever ran as an informational, non-failing job. Ran a full **online** sweep and hand-verified every failure.

## Method

lychee online sweep over all tracked Markdown (~2040 unique links), then each failure re-checked by hand (browser user-agent + DNS lookup) to separate **truly dead** domains from **bot-blocking / transient timeouts**. Most automated "errors" were bot-blocks and were dismissed.

## Fixed — confirmed dead/retired, repointed to verified successors (all 200)

| Dead link | Why | Now points to |
|-----------|-----|---------------|
| `farsightsecurity.com` | NXDOMAIN — Farsight acquired by DomainTools (2021) | DomainTools DNSDB |
| `community.riskiq.com` | RiskIQ acquired by Microsoft; portal retired | Microsoft Defender Threat Intelligence |
| `onion.link` | Tor2web deprecated (2019), gateway defunct | Ahmia |
| `zonefiles.io` | NXDOMAIN | entry kept, dead link removed, WhoisXML/Whoisds noted |

Nothing was deleted — each catalog entry stays, with the link corrected and a short note on what changed.

## Flagged for manual review (not changed)

`abusix.org`, `emailcrawlr.com`, `threatjammer.com`, `got-hacked.wtf` — hosts resolve but block automated checks (WAF/TLS quirks), so they likely work for humans. Left as-is to avoid breaking working links; noted in the register. (`got-hacked.wtf` serves a default "Plesk" cert — worth a human look.)

Also: `qdkingst.com` failed the automated sweep but verified working by hand — the F-05 HTTPS upgrade stands.

## Verification

- All 4 successor URLs + 2 suggested alternatives verified live (200)
- 0 clickable links to dead domains remain
- `markdownlint-cli2`: 0 issues; offline anchor/link check: 0 errors

Documented as **F-10** in `AUDIT_FINDINGS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)