### PR TITLE
fix(F-09): standardize the offensive-content safety header

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -41,7 +41,7 @@ source; **Medium** = verified pattern but individual instances need a human call
 | F-06 | Low | Content | `TODO` / placeholder / `TBD` markers left in published docs | 9 | High | ✅ Resolved — intentional (#25) |
 | F-07 | Editorial | Structure | Very large monolithic guides are candidates for splitting | 4 docs | Low | ⏸️ Deferred by owner |
 | F-08 | Medium | Duplication | Core topics duplicated across several root "master guide" docs with no canonical source | 6+ topics | High | 🔵 Open — plan in report |
-| F-09 | Medium | Safety | Inconsistent prominence of the safety/authorization header on offensive docs | ~3 docs | Medium | 🔵 Open — plan in report |
+| F-09 | Medium | Safety | Inconsistent prominence of the safety/authorization header on offensive docs | ~3 docs | Medium | ✅ Fixed |
 | F-10 | Low | Link hygiene | Dead/retired external links (scope 10, online sweep) | 4 fixed, 4 flagged | High | ✅ Fixed dead links; 4 flagged for manual review |
 
 *Findings F-08–F-09 come from the second audit pass (scope 2/4/11). The
@@ -280,7 +280,7 @@ each fix should be visually confirmed in GitHub's preview.*
 
 ## F-09 — Inconsistent safety/authorization header on offensive docs
 
-- **Priority:** Medium **Category:** Safety (scope 4) **Confidence:** Medium **Status:** 🔵 Open — plan in [report](./AUDIT_REPORT.md)
+- **Priority:** Medium **Category:** Safety (scope 4) **Confidence:** Medium **Status:** ✅ Fixed — standard header added to `STYLE_GUIDE.md` §4 and applied to the 5 offensive root guides
 - **Issue:** Offensive documents all *reference* authorized use, but the
   prominence is inconsistent — from a full warning block (`SDR/README.md`,
   `SPECIALIZED_TOPICS_GUIDE.md`: ~38 warning-related lines) down to a single

--- a/ENHANCED_MASTER_GUIDE.md
+++ b/ENHANCED_MASTER_GUIDE.md
@@ -1,5 +1,11 @@
 # ENHANCED CYBERSECURITY MASTER GUIDE
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+
 ## 🎯 Purpose
 Enhanced version of the Ultimate Cybersecurity Master Guide - layers 90+ PNWC internal documents, KB articles, and operational experience on top of the foundational content from 70+ professional security books.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -44,7 +44,28 @@
 
 ---
 
-## 4. Cross-Referencing & Navigation
+## 4. Offensive-Content Safety Header
+
+Any guide whose primary subject is offensive or dual-use tradecraft (exploitation,
+post-exploitation, evasion, credential attacks, RF transmission, etc.) must open
+with a standard authorization callout, placed immediately after the H1 (and any
+badge/image block), before the Purpose block. Use the existing alert convention:
+
+```markdown
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+```
+
+This is a **document-level** complement to the per-script disclaimer in §3 — a
+reader landing anywhere in an offensive guide should see the authorization
+boundary near the top. It **adds** context; it never replaces or removes content.
+
+---
+
+## 5. Cross-Referencing & Navigation
 
 - **Navigation Footer:** Long guides should end with a standard navigation footer:
   ```markdown
@@ -56,7 +77,7 @@
 
 ---
 
-## 5. Review Metadata
+## 6. Review Metadata
 
 - **Last-Reviewed Line:** Reference and install/tool docs should carry a review date near the top, immediately under the H1 (or under any badge/image block):
 

--- a/advanced_techniques_part2.md
+++ b/advanced_techniques_part2.md
@@ -1,5 +1,11 @@
 # Advanced Cybersecurity Techniques - Part 2
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+
 ## 🎯 Purpose
 Advanced cybersecurity techniques Part 2 - covering exploit development, buffer overflows, shellcode writing, and custom payload creation for experienced security practitioners.
 

--- a/advanced_techniques_supplement.md
+++ b/advanced_techniques_supplement.md
@@ -1,5 +1,11 @@
 # Advanced Cybersecurity Techniques - Professional Supplement
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+
 ## 🎯 Purpose
 Advanced cybersecurity techniques Part 1 - covering advanced Metasploit usage, cloud penetration testing, lateral movement techniques, and network pivoting for experienced practitioners.
 

--- a/cybersecurity_cliff_notes.md
+++ b/cybersecurity_cliff_notes.md
@@ -1,5 +1,11 @@
 # Cybersecurity Comprehensive Cliff Notes
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+
 ## 🎯 Purpose
 Quick command reference for the most essential cybersecurity tools and techniques - the key commands practitioners reach for most often during authorized engagements.
 

--- a/ultimate_cybersecurity_master_guide.md
+++ b/ultimate_cybersecurity_master_guide.md
@@ -1,5 +1,11 @@
 # The Ultimate Cybersecurity Master Guide
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](LEGAL.md).
+
 ## 🎯 Purpose
 Foundational cybersecurity master guide compiled from 70+ professional security books - covering the complete penetration testing lifecycle with expert-sourced methodology and key takeaways.
 


### PR DESCRIPTION
Fixes **F-09** (Medium, scope 4) from `AUDIT_FINDINGS.md`.

## Problem

Offensive guides all *mentioned* authorized use, but only in prose (a Purpose/Goal line). None had a prominent, consistent authorization callout near the top, so a reader landing mid-document wouldn't see the boundary.

## Fix

1. **Defined a standard** — new `STYLE_GUIDE.md` §4 "Offensive-Content Safety Header" specifies a document-level `> [!CAUTION]` authorization block, placed right after the H1, using the repo's existing alert convention.
2. **Applied it** to the five offensive root guides that lacked one:
   - `ultimate_cybersecurity_master_guide.md`
   - `ENHANCED_MASTER_GUIDE.md`
   - `advanced_techniques_supplement.md`
   - `advanced_techniques_part2.md`
   - `cybersecurity_cliff_notes.md`

Each now opens with a standard authorization CAUTION linking to `LEGAL.md`.

**Purely additive** — no content removed or altered, consistent with the standing "don't sterilize" constraint. Docs that already had strong warning blocks (SDR, SPECIALIZED_TOPICS) were left as-is.

## Verification

- All 5 headers confirmed present near the top
- `markdownlint-cli2`: 0 issues / 7 files
- Offline anchor/link check: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)