### PR TITLE
fix(F-08): add canonical cross-links for duplicated topics

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -40,7 +40,7 @@ source; **Medium** = verified pattern but individual instances need a human call
 | F-05 | Low | Link hygiene | External links using `http://` where `https://` may be available | 6 hosts | Medium | ✅ Fixed (#25) |
 | F-06 | Low | Content | `TODO` / placeholder / `TBD` markers left in published docs | 9 | High | ✅ Resolved — intentional (#25) |
 | F-07 | Editorial | Structure | Very large monolithic guides are candidates for splitting | 4 docs | Low | ⏸️ Deferred by owner |
-| F-08 | Medium | Duplication | Core topics duplicated across several root "master guide" docs with no canonical source | 6+ topics | High | 🔵 Open — plan in report |
+| F-08 | Medium | Duplication | Core topics duplicated across several root "master guide" docs with no canonical source | 6+ topics | High | ✅ Fixed (canonical cross-links) |
 | F-09 | Medium | Safety | Inconsistent prominence of the safety/authorization header on offensive docs | ~3 docs | Medium | ✅ Fixed |
 | F-10 | Low | Link hygiene | Dead/retired external links (scope 10, online sweep) | 4 fixed, 4 flagged | High | ✅ Fixed dead links; 4 flagged for manual review |
 
@@ -255,7 +255,7 @@ each fix should be visually confirmed in GitHub's preview.*
 
 ## F-08 — Core topics duplicated across "master guide" docs (no canonical source)
 
-- **Priority:** Medium **Category:** Duplication (scope 11) **Confidence:** High **Status:** 🔵 Open — plan in [report](./AUDIT_REPORT.md)
+- **Priority:** Medium **Category:** Duplication (scope 11) **Confidence:** High **Status:** ✅ Fixed — additive canonical cross-links added under each duplicated section (no content removed)
 - **Issue:** Several core topics are covered in 2–3 root-level guides with no
   designated canonical source, so updates must be repeated or the copies drift.
   Observed overlap (by section headings):

--- a/ENHANCED_MASTER_GUIDE.md
+++ b/ENHANCED_MASTER_GUIDE.md
@@ -41,6 +41,12 @@ Serve as the definitive single-document cybersecurity reference that combines ac
 4. [Anonymity & Privacy Protection](#anonymity--privacy-protection)
 
 ## OSINT MASTERY
+
+> [!NOTE]
+> **Canonical reference:** the dedicated, maintained OSINT section is
+> [OSINT/](OSINT/README.md) (tools catalog, cheat sheet, per-platform guides,
+> investigator playbook). Keep major OSINT updates there; this is an embedded
+> summary.
 5. [Comprehensive OSINT Resources](#comprehensive-osint-resources)
 6. [OSINT Virtual Machines](#osint-vm-setup)
 7. [OSINT Tools & Software](#part-3-osint-tools--software)

--- a/advanced_techniques_part2.md
+++ b/advanced_techniques_part2.md
@@ -485,6 +485,11 @@ s.close()
 
 ## Mobile Device Penetration Testing
 
+> [!NOTE]
+> **Related:** the dedicated mobile section — including device-specific SOPs — is
+> [Mobile/](Mobile/README.md). This section covers the penetration-testing
+> techniques.
+
 ### Android Application Security
 
 #### APK Analysis Workflow

--- a/cybersecurity_cliff_notes.md
+++ b/cybersecurity_cliff_notes.md
@@ -632,6 +632,11 @@ ruby: exec "/bin/sh"
 
 ## Metasploit Framework
 
+> [!NOTE]
+> **Canonical reference:** the deepest Metasploit treatment lives in
+> [advanced_techniques_supplement.md](advanced_techniques_supplement.md#advanced-metasploit-techniques).
+> These are quick-reference notes.
+
 ### Basic Commands
 ```bash
 # Start Metasploit

--- a/ultimate_cybersecurity_master_guide.md
+++ b/ultimate_cybersecurity_master_guide.md
@@ -322,6 +322,11 @@ tail -f /var/log/syslog | grep --line-buffered "ERROR"
 
 ## Python for Security Professionals
 
+> [!NOTE]
+> **Canonical reference:** advanced Python automation lives in
+> [advanced_techniques_supplement.md](advanced_techniques_supplement.md#python-for-security-automation).
+> Keep major updates there; this section is a foundational summary.
+
 ### Python Basics for Security
 
 #### Essential Python Constructs
@@ -446,6 +451,11 @@ def port_scanner(target, ports):
 ---
 
 ## Bash Scripting for Red Teams
+
+> [!NOTE]
+> **Canonical reference:** advanced offensive Bash lives in
+> [advanced_techniques_supplement.md](advanced_techniques_supplement.md#bash-scripting-for-offensive-security).
+> Keep major updates there; this section is a foundational summary.
 
 ### Bash Script Fundamentals
 
@@ -702,6 +712,11 @@ sqlmap -u "http://target.com/page?id=1" -D database --tables
 
 ## Metasploit Framework Mastery
 
+> [!NOTE]
+> **Canonical reference:** the deepest Metasploit treatment lives in
+> [advanced_techniques_supplement.md](advanced_techniques_supplement.md#advanced-metasploit-techniques).
+> Keep major updates there; this section is a foundational summary.
+
 ### Basic Metasploit Usage
 ```bash
 # Start Metasploit
@@ -744,6 +759,11 @@ run -j
 ---
 
 ## Buffer Overflow Exploitation
+
+> [!NOTE]
+> **Canonical reference:** in-depth exploit development lives in
+> [advanced_techniques_part2.md](advanced_techniques_part2.md#buffer-overflow-exploitation).
+> Keep major updates there; this section is a foundational summary.
 
 ### Stack Buffer Overflow Basics
 1. Fuzzing to find crash
@@ -968,6 +988,12 @@ aws ec2 describe-instances
 ---
 
 ## Mobile Device Security
+
+> [!NOTE]
+> **Canonical reference:** the dedicated mobile section is [Mobile/](Mobile/README.md);
+> deeper mobile pentesting is in
+> [advanced_techniques_part2.md](advanced_techniques_part2.md#mobile-device-penetration-testing).
+> This section is a foundational summary.
 
 ### Android Security Testing
 ```bash


### PR DESCRIPTION
Fixes **F-08** (Medium, scope 11) from `AUDIT_FINDINGS.md`.

## Problem

Core topics were covered in 2–3 root-level guides with no designated canonical source, so updates had to be repeated or the copies drifted.

## Fix (additive — nothing deleted)

Rather than delete duplicated content (which you asked to avoid), each duplicated section now carries a `> [!NOTE] Canonical reference` pointer to the deepest/maintained source:

| Doc → section | Points to |
|---------------|-----------|
| `ultimate_…master_guide` → Metasploit | supplement (Advanced Metasploit) |
| `ultimate_…` → Buffer Overflow | part2 (exploit dev) |
| `ultimate_…` → Python / Bash | supplement (automation / offensive Bash) |
| `ultimate_…` → Mobile | `Mobile/` + part2 |
| `cybersecurity_cliff_notes` → Metasploit | supplement |
| `advanced_techniques_part2` → Mobile Pentesting | `Mobile/` |
| `ENHANCED_MASTER_GUIDE` → OSINT Mastery | `OSINT/` |

Now there's a clear canonical home per topic, while every existing section stays intact as a summary/complement.

## Verification

- All new cross-file anchors resolve — lychee `--include-fragments`: **0 errors**
- `markdownlint-cli2`: 0 issues
- Diff is +44/−2 — purely added NOTE callouts

With this, **F-01 through F-10 are all resolved or owner-deferred** (F-07). Remaining audit work is the deeper per-domain factual (scope 2) and destructive-command safety (scope 4) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)