### PR TITLE
audit(scope 2/4): IncidentResponse forensics review — Volatility guide

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -335,6 +335,30 @@ findings were raised for it. Recorded here for honesty about what was checked:
 
 ---
 
+## Domain review log (scope 2 & 4, per-domain)
+
+The systematic per-domain review runs one domain at a time; results recorded here
+as each completes.
+
+### IncidentResponse — Digital Forensics (2026-08-03)
+
+- **Scope 2 (accuracy):** ✅ Clean. Verified the Volatility 3 command surface in
+  `Memory/volatility_cheatsheet.md` against upstream — plugin namespacing
+  (`windows.pslist/pstree/psscan/cmdline/netscan/malfind/hashdump/lsadump/
+  cachedump`, `windows.registry.*`), render flags (`-r json`), dump syntax
+  (`-o <dir> … --dump`), the symbol-pack URL, and acquisition tools (DumpIt,
+  WinPMEM, FTK Imager, Magnet, LiME, AVML) are all correct.
+- **Scope 4 (safety/forensic soundness):** Strong at the domain level — the
+  README, disk, and live-data guides cover order of volatility, write-blocking,
+  chain of custody, and hashing. **Fixed:** the memory guide's acquisition
+  section didn't remind the reader to hash the acquired image; added an integrity
+  / chain-of-custody note cross-linking the README's evidence-handling guidance.
+- **Currency:** ✅ Fixed — WinPMEM was attributed to the defunct Rekall project;
+  updated to Velocidex (current maintainer).
+- **Verdict:** high-quality, factually sound; two small additive corrections.
+
+---
+
 ## Open workstreams (not yet itemized as findings)
 
 These audit-scope areas were **not** covered in this structural pass and are not

--- a/IncidentResponse/Digital-Forensics/Memory/volatility_cheatsheet.md
+++ b/IncidentResponse/Digital-Forensics/Memory/volatility_cheatsheet.md
@@ -127,6 +127,14 @@ python3 vol.py --help | grep windows
 
 Before analysis, you need a memory dump. Several tools can capture RAM from live systems.
 
+> [!IMPORTANT]
+> **Preserve integrity as you acquire.** Live acquisition itself perturbs RAM, so
+> capture memory **first** (order of volatility) and with the smallest footprint
+> tool available. Immediately hash the resulting image
+> (`sha256sum image.raw > image.raw.sha256`) and record it in your notes — this
+> establishes integrity for chain of custody. See the section's evidence-handling
+> guidance in [Digital-Forensics/README.md](../README.md#-order-of-volatility).
+
 ### Windows Memory Acquisition
 
 #### DumpIt (Recommended for Simplicity)
@@ -140,7 +148,7 @@ DumpIt.exe
 
 Output: Creates a raw memory dump in the current directory.
 
-#### WinPMEM (Rekall Project)
+#### WinPMEM (Velocidex; formerly Rekall)
 
 ```cmd
 :: Capture to raw format


### PR DESCRIPTION
First **per-domain factual/safety review** (audit scope 2 & 4), starting with Digital Forensics — the deeper verification the earlier passes only sampled.

## Scope 2 — factual accuracy ✅ clean

Verified the Volatility 3 command surface in `volatility_cheatsheet.md` against upstream: plugin namespacing (`windows.pslist/pstree/psscan/cmdline/netscan/malfind/hashdump/lsadump/cachedump`, `windows.registry.*`), render flags (`-r json`), dump syntax (`-o <dir> … --dump`), the symbol-pack URL, and acquisition tools (DumpIt, WinPMEM, FTK Imager, Magnet, LiME, AVML) are **all correct**. No factual defects.

## Scope 4 — forensic soundness

The domain covers order of volatility, write-blocking, chain of custody, and hashing well overall (README + disk + live-data guides). One gap in the **memory** guide:

- **Fixed (additive):** the acquisition section didn't remind the reader to hash the acquired image. Added an `> [!IMPORTANT]` integrity / chain-of-custody note that cross-links the README's evidence-handling section.

## Currency

- **Fixed:** WinPMEM was attributed to the defunct **Rekall** project → updated to **Velocidex** (current maintainer; repo verified live).

## Notes

- Verdict: high-quality, factually sound domain — two small additive corrections only.
- Logged under a new "Domain review log" in `AUDIT_FINDINGS.md`; nothing removed.
- Cross-link anchor verified (lychee `--include-fragments`: 0 errors); markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)