### PR TITLE
audit(scope 2/4): IncidentResponse Endpoint-Visibility review

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -357,6 +357,22 @@ as each completes.
   updated to Velocidex (current maintainer).
 - **Verdict:** high-quality, factually sound; two small additive corrections.
 
+### IncidentResponse — Endpoint Visibility (2026-08-03)
+
+- **Scope 2 (accuracy):** verified Sysmon install/config commands (`-accepteula -i`,
+  `-c`, schemaversion 4.90), auditd rule syntax (`-w … -p wa -k`,
+  `-a always,exit -S execve`, `augenrules`, `systemctl … auditd`), and the Sysmon
+  and SwiftOnSecurity config download URLs — all correct/live.
+- **Fixed (currency / dead links) in `Linux/osquery.md`:**
+  - `osquery.io/schema/5.14.0/` returned 404 (verified with curl **and** lychee;
+    site content changed since the F-10 sweep) → replaced with the actively
+    maintained [Fleet tables reference](https://fleetdm.com/tables).
+  - `github.com/kolide/fleet` is **archived** → repointed to the active
+    `fleetdm/fleet` (the `fleetdm.com` landing was already linked separately).
+- **Scope 4:** deployment-impact / tuning / noise-baseline guidance is present in
+  all three endpoint guides — adequate.
+- **Verdict:** sound; two dead/stale links fixed in the osquery guide.
+
 ---
 
 ## Open workstreams (not yet itemized as findings)

--- a/IncidentResponse/Endpoint-Visibility/Linux/osquery.md
+++ b/IncidentResponse/Endpoint-Visibility/Linux/osquery.md
@@ -1060,7 +1060,7 @@ If using Fleet for central management:
 ### Documentation
 
 - [Osquery Documentation](https://osquery.readthedocs.io/)
-- [Osquery Schema](https://osquery.io/schema/5.14.0/)
+- [Osquery Schema (Fleet tables reference)](https://fleetdm.com/tables)
 - [Osquery GitHub](https://github.com/osquery/osquery)
 
 ### Query Packs
@@ -1072,7 +1072,7 @@ If using Fleet for central management:
 ### Fleet Management
 
 - [Fleet (FleetDM)](https://fleetdm.com/)
-- [Kolide Fleet](https://github.com/kolide/fleet)
+- [Fleet on GitHub](https://github.com/fleetdm/fleet) *(the old `kolide/fleet` repo is archived)*
 
 ### Community
 


### PR DESCRIPTION
Continues the per-domain factual/safety review with the endpoint-visibility guides (Sysmon, osquery, auditd).

Verified correct/live: Sysmon install/config commands and schema version, auditd rule syntax, and the Sysmon + SwiftOnSecurity config download URLs.

Fixed two dead/stale links in Linux/osquery.md (both re-verified with curl and lychee):
- osquery.io/schema/5.14.0/ now 404s -> Fleet's maintained tables reference (fleetdm.com/tables), which tracks the current schema without version pinning
- github.com/kolide/fleet is archived -> active fleetdm/fleet repo

Scope 4: deployment-impact/tuning guidance present in all three guides. Logged under the Domain review log in AUDIT_FINDINGS.md. No content removed.

<!-- Thanks for contributing! Please complete the checklist below. -->

## Summary

<!-- What does this PR change and why? -->

## Type of change

- [ ] Fix (broken link, typo, factual/command error)
- [ ] Update (refresh outdated tool/version/procedure)
- [ ] New content (tool, guide, script, section)
- [ ] Maintenance (tooling, formatting, structure)

## Checklist

- [ ] Internal links use **relative paths** and resolve (the Link Check workflow passes)
- [ ] Any renamed/moved files have **all referring links updated**
- [ ] New Markdown follows [STYLE_GUIDE.md](../STYLE_GUIDE.md) (single H1, logical heading levels)
- [ ] Offensive/dual-use scripts include an **authorized-use disclaimer** and note prerequisites
- [ ] Destructive commands carry a **warning + safer alternative / rollback** where relevant
- [ ] Technical claims cite an **authoritative source** where practical (vendor/CISA/NIST/MITRE/OWASP)

## Sources / verification

<!-- Links to authoritative sources you verified against, and the date. -->
