### PR TITLE
audit(scope 2/4): IncidentResponse SIEM + log aggregation review

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -373,6 +373,25 @@ as each completes.
   all three endpoint guides — adequate.
 - **Verdict:** sound; two dead/stale links fixed in the osquery guide.
 
+### IncidentResponse — SIEM + log aggregation (2026-08-03)
+
+- **Scope 2 (accuracy):** verified install/repo commands, ports, and config across
+  Splunk, ELK, Graylog, and Wazuh guides. Splunkbase app IDs and the Elastic /
+  Wazuh package repos are valid. `elk_stack.md` pins Elastic `8.12.0` with an
+  **exemplary** explicit note pointing at the 9.x line — left as a model to copy.
+- **Fixed:**
+  - `wazuh.md`: the standalone `wazuh/wazuh-ruleset` repo is **archived** → link
+    repointed to the ruleset in the main `wazuh/wazuh` repo.
+  - `wazuh.md`: the guide pins Wazuh `4.7.0` (current `4.14.x`, `5.0` beta) with
+    no note — added a currency note mirroring the ELK one (pinned artifacts were
+    verified still live, so the guide still works as written).
+  - `log_agg.md`: the "SANS Log Management Cheat Sheet" link (a blog tag page)
+    now 404s → replaced with the authoritative **NIST SP 800-92**.
+- **Scope 4:** SIEM guides are defensive infrastructure; risk is deployment/config
+  rather than offensive — no safety-header gap.
+- **Verdict:** sound; three stale/dead links fixed, one currency note added.
+  **IncidentResponse domain review complete.**
+
 ---
 
 ## Open workstreams (not yet itemized as findings)

--- a/IncidentResponse/SIEM/wazuh.md
+++ b/IncidentResponse/SIEM/wazuh.md
@@ -91,6 +91,14 @@ docker compose version
 
 ## 🚀 Part 2: Deploying the Wazuh Manager (Docker)
 
+> [!NOTE]
+> This guide pins Wazuh `4.7.0` for a known-good, internally consistent config.
+> The current line is `4.14.x` (with `5.0` in beta) — check the
+> [Wazuh releases](https://github.com/wazuh/wazuh/releases) and
+> [wazuh-docker releases](https://github.com/wazuh/wazuh-docker/releases) before
+> deploying, since version bumps can change the compose files and default
+> settings used below.
+
 ### Step 2.1: Clone the Wazuh Docker Repository
 
 ```bash
@@ -459,7 +467,7 @@ docker compose up -d
 
 - [Wazuh Documentation](https://documentation.wazuh.com/)
 - [Wazuh GitHub Repository](https://github.com/wazuh/wazuh)
-- [Wazuh Ruleset](https://github.com/wazuh/wazuh-ruleset)
+- [Wazuh Ruleset](https://github.com/wazuh/wazuh/tree/main/ruleset) *(the standalone `wazuh-ruleset` repo is archived; rules now ship in the main repo)*
 - [Wazuh Slack Community](https://wazuh.com/community/join-us-on-slack/)
 
 ---

--- a/IncidentResponse/log_agg.md
+++ b/IncidentResponse/log_agg.md
@@ -991,7 +991,7 @@ sudo chown syslog:adm /var/log/remote
 - [Rsyslog Documentation](https://www.rsyslog.com/doc/)
 - [Wazuh Log Collection](https://documentation.wazuh.com/current/user-manual/capabilities/log-data-collection/)
 - [Elastic Common Schema](https://www.elastic.co/guide/en/ecs/current/index.html)
-- [SANS Log Management Cheat Sheet](https://www.sans.org/blog/tag/log-management/)
+- [NIST SP 800-92 — Guide to Computer Security Log Management](https://csrc.nist.gov/pubs/sp/800/92/final)
 
 ---
 


### PR DESCRIPTION
Completes the **IncidentResponse per-domain review** with the SIEM guides (Splunk, ELK, Graylog, Wazuh) and log aggregation.

## Scope 2 — accuracy

**Verified:** install/repo commands, ports, and config across all four SIEM guides; Splunkbase app IDs and the Elastic/Wazuh package repos are valid. `elk_stack.md` pins Elastic `8.12.0` with an **exemplary** version note pointing at the 9.x line — left as a model for the others.

**Fixed** (each re-verified with curl + lychee):

| File | Problem | Fix |
|------|---------|-----|
| `wazuh.md` | `wazuh/wazuh-ruleset` repo is **archived** | ruleset in main `wazuh/wazuh` repo |
| `wazuh.md` | pins Wazuh `4.7.0` (current `4.14.x`) with no note | added currency note mirroring ELK's (pinned artifacts verified still live) |
| `log_agg.md` | "SANS Log Management" blog-tag link **404s** | authoritative **NIST SP 800-92** |

## Scope 4 — safety

SIEM guides are defensive infrastructure; risk is deployment/config, not offensive — no safety-header gap.

## Status

**IncidentResponse domain review complete** (Digital-Forensics ✅, Endpoint-Visibility ✅, SIEM ✅). Logged in the register's Domain review log; nothing removed. markdownlint clean; offline anchor check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)