### PR TITLE
audit(scope 2/4): Tradecraft domain review

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -392,6 +392,23 @@ as each completes.
 - **Verdict:** sound; three stale/dead links fixed, one currency note added.
   **IncidentResponse domain review complete.**
 
+### Tradecraft (2026-08-03)
+
+- **Scope 2 (accuracy):** command syntax and tool references check out.
+  Deprecations are already well-handled in-place — CrackMapExec carries a note
+  that it is archived and `nxc` (NetExec) is the successor; twint/snscrape carry a
+  note about X's 2023 API lockdown. No factual defects.
+- **Scope 4 (safety):** applied the standard authorization header (F-09) to the
+  three dual-use offensive guides that lacked one — `active-directory.md`,
+  `av-edr-evasion.md`, `lolbins-lolbas.md`. `c2-frameworks.md` and
+  `osint-threat-intel.md` already had one; `network-detection.md` is defensive
+  (Zeek/Suricata/packet analysis) and doesn't need the offensive header.
+- **Fixed (dead links):** two more rotted SANS blog-tag pages (404) →
+  `network-detection.md` now cites **NIST SP 800-86**; `osint-threat-intel.md`
+  now points at the stable SANS **posters** landing.
+- **Verdict:** sound; safety-header coverage completed for the offensive guides,
+  two dead links fixed. **Tradecraft domain review complete.**
+
 ---
 
 ## Open workstreams (not yet itemized as findings)

--- a/Tradecraft/active-directory.md
+++ b/Tradecraft/active-directory.md
@@ -1,5 +1,10 @@
 # Active Directory - Attacks & Defense Deep Dive
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](../LEGAL.md).
 
 ## 🎯 Purpose
 Complete Active Directory attack and defense reference - covering enumeration, Kerberos abuse (Kerberoasting, AS-REP, Golden/Silver tickets), lateral movement, persistence, DCSync, and corresponding detection logic with BloodHound integration.

--- a/Tradecraft/av-edr-evasion.md
+++ b/Tradecraft/av-edr-evasion.md
@@ -1,5 +1,10 @@
 # AV/EDR Evasion - Detection & Defense Deep Dive
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](../LEGAL.md).
 
 ## 🎯 Purpose
 AV/EDR evasion techniques reference for blue team and purple team - covering how each evasion technique works, what artifacts it leaves, and how to detect, hunt, and harden against it.

--- a/Tradecraft/lolbins-lolbas.md
+++ b/Tradecraft/lolbins-lolbas.md
@@ -1,5 +1,10 @@
 # Living Off the Land - LOLBins, LOLBAs, LOLScripts
 
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized security
+> testing, education, and defensive research. Using them against systems you do
+> not own or lack explicit written permission to test is illegal. See
+> [LEGAL.md](../LEGAL.md).
 
 ## 🎯 Purpose
 LOLBins and LOLBAs reference - legitimate Windows binaries, libraries, and scripts that can be abused for execution, download, lateral movement, and defense evasion without dropping traditional malware.

--- a/Tradecraft/network-detection.md
+++ b/Tradecraft/network-detection.md
@@ -1143,7 +1143,7 @@ Get-WinEvent -LogName "Microsoft-Windows-Sysmon/Operational" -FilterXPath `
 - [Zeek Documentation](https://docs.zeek.org/)
 - [Suricata Documentation](https://docs.suricata.io/en/latest/)
 - [Emerging Threats Rules](https://rules.emergingthreats.net/)
-- [SANS Network Forensics Cheat Sheet](https://www.sans.org/blog/tag/network-forensics/)
+- [NIST SP 800-86 — Integrating Forensic Techniques into Incident Response](https://csrc.nist.gov/pubs/sp/800/86/final)
 - [Arkime (Moloch)](https://arkime.com/)
 - [JA3 Fingerprints Database](https://sslbl.abuse.ch/ja3-fingerprints/)
 - [MITRE ATT&CK: Exfiltration Over C2](https://attack.mitre.org/tactics/TA0010/)

--- a/Tradecraft/osint-threat-intel.md
+++ b/Tradecraft/osint-threat-intel.md
@@ -1094,7 +1094,7 @@ sudo apt install kali-tools-information-gathering
 - [OSINT Framework](https://osintframework.com/)
 - [Bellingcat OSINT Toolkit](https://docs.google.com/spreadsheets/d/18rtqh8EG2q1xBo2cLNyhIDuK9jrPGwYr9DI2UncoqJQ/edit)
 - [MITRE ATT&CK: Reconnaissance](https://attack.mitre.org/tactics/TA0043/)
-- [SANS OSINT Poster](https://www.sans.org/blog/tag/osint/)
+- [SANS Posters (OSINT & DFIR)](https://www.sans.org/posters/)
 - [IntelTechniques](https://inteltechniques.com/tools/)
 - [Trace Labs CTF (missing persons OSINT)](https://www.tracelabs.org/)
 - [OSINT Curious](https://osintcurio.us/)


### PR DESCRIPTION
Per-domain factual/safety review of the **Tradecraft** (offensive) domain — AD attacks, AV/EDR evasion, C2, LOLBins, network detection, OSINT/threat-intel.

## Scope 2 — accuracy

Command syntax and tool references check out. Deprecations are **already handled in-place**: CrackMapExec carries an "archived → use `nxc`/NetExec" note; twint/snscrape carry an "X 2023 API lockdown" note. No factual defects.

## Scope 4 — safety (main outcome)

Applied the standard **F-09 authorization header** to the three dual-use offensive guides that lacked one:

- `active-directory.md`, `av-edr-evasion.md`, `lolbins-lolbas.md`

(`c2-frameworks.md` and `osint-threat-intel.md` already had one; `network-detection.md` is defensive — Zeek/Suricata/packet analysis — so it doesn't need the offensive header.)

## Dead links fixed

Two more rotted SANS blog-tag pages (404, same pattern as prior PRs):

| File | Now cites |
|------|-----------|
| `network-detection.md` | **NIST SP 800-86** (network forensics guide) |
| `osint-threat-intel.md` | stable SANS **posters** landing |

## Status

**Tradecraft domain review complete.** Logged in the register's Domain review log; nothing removed. markdownlint clean; offline anchor/link check 0 errors (incl. the new `../LEGAL.md` links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)