### PR TITLE
audit(scope 2/4): OSINT domain review + repo-wide SANS link sweep

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -409,6 +409,30 @@ as each completes.
 - **Verdict:** sound; safety-header coverage completed for the offensive guides,
   two dead links fixed. **Tradecraft domain review complete.**
 
+### OSINT (2026-08-03)
+
+- **Scope 2 (accuracy):** ✅ well-maintained. Tool-install repos are correct and
+  active (theHarvester, sherlock, spiderfoot, Photon — none archived); no
+  undocumented dead tools (twint's X-API breakage is already noted). The tools
+  catalog had 4 dead links fixed earlier (F-10).
+- **Scope 4 (legal/ethical):** ✅ exceptionally strong — 100+ legal/ethical/
+  authorization references in `OSINT/README.md` alone, plus per-guide framing.
+- **Still flagged (unchanged):** the 5 F-10 hosts in `OSINT_TOOLS_CATALOG.md`
+  (abusix.org, threatjammer.com, emailcrawlr.com, got-hacked.wtf, spyonweb.com)
+  still resolve but block automated requests even with a browser UA. abusix.org
+  is a known-active company, so these read as WAF / datacenter-IP blocking rather
+  than dead sites — **not** changed, to avoid removing working resources on weak
+  evidence. Worth a human eyeball.
+- **Verdict:** high quality; no changes needed beyond the repo-wide SANS sweep.
+
+### Repo-wide dead-link sweeps (2026-08-03)
+
+- **SANS `/blog/tag/*` link rot (systematic):** SANS reorganised their blog and
+  removed all tag pages. Fixed every occurrence found repo-wide —
+  `log_agg.md`, `network-detection.md`, `osint-threat-intel.md`, and
+  `Digital-Forensics/Disks/autopsy_kape.md` (→ NIST SP 800-86 / SP 800-92 /
+  SANS course & poster landings). No `sans.org/blog/tag/` links remain.
+
 ---
 
 ## Open workstreams (not yet itemized as findings)

--- a/IncidentResponse/Digital-Forensics/Disks/autopsy_kape.md
+++ b/IncidentResponse/Digital-Forensics/Disks/autopsy_kape.md
@@ -815,7 +815,7 @@ Remove-Item -Recurse "$env:USERPROFILE\.autopsy"
 
 - [Autopsy User Documentation](https://sleuthkit.org/autopsy/docs/user-docs/4.19.3/)
 - [KAPE Documentation](https://ericzimmerman.github.io/KapeDocs/)
-- [SANS DFIR Resources](https://www.sans.org/blog/tag/dfir/)
+- [SANS DFIR Courses & Resources](https://www.sans.org/cyber-security-courses/?focus-area=digital-forensics-incident-response)
 
 ### Training
 


### PR DESCRIPTION
Per-domain review of the **OSINT** domain, plus a repo-wide sweep of the systematic SANS link-rot.

## OSINT review — high quality, no changes needed

- **Scope 2 (accuracy):** tool-install repos are correct and **active** (theHarvester, sherlock, spiderfoot, Photon — none archived); no undocumented dead tools (twint's X-API breakage is already noted). The tools catalog's 4 dead links were fixed earlier in F-10.
- **Scope 4 (legal/ethical):** exceptionally strong — 100+ legal/ethical/authorization references in `OSINT/README.md` alone.
- **5 hosts stay flagged (unchanged):** the F-10 catalog hosts (abusix.org, threatjammer.com, emailcrawlr.com, got-hacked.wtf, spyonweb.com) still resolve but block automated requests even with a browser UA. **abusix.org is a known-active company**, so these read as WAF / datacenter-IP blocking, not dead sites — deliberately **not** changed, to avoid removing working resources on weak evidence. Worth a human eyeball.

## Repo-wide SANS `/blog/tag/*` sweep

SANS removed all blog tag pages (a systematic 404 class I'd been hitting one file at a time). Swept the whole repo and fixed the last remaining one — `autopsy_kape.md`'s SANS DFIR link → SANS DFIR course/resource landing. **No `sans.org/blog/tag/` links remain anywhere.**

## Status

OSINT domain review complete (3 domains done: IncidentResponse, Tradecraft, OSINT). Logged in the register; nothing removed. markdownlint clean; offline anchor check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)