### PR TITLE
audit(scope 2/4): SDR/RF domain review

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -425,6 +425,20 @@ as each completes.
   evidence. Worth a human eyeball.
 - **Verdict:** high quality; no changes needed beyond the repo-wide SANS sweep.
 
+### SDR / RF (2026-08-03)
+
+- **Scope 2 (accuracy):** ✅ sound. RF/regulatory claims check out (FCC framing,
+  APRS 144.390 MHz, band references); tool references current; `gr-gsm`'s
+  upstream-unmaintained status is already noted.
+- **Scope 4 (safety):** ✅ strong — the domain treats RF transmission as the
+  high-risk activity it is. `SDR/README.md` carries a prominent federal-offense
+  transmission warning; both `sdr.md` and `sdr_hacking.md` have early RF-safety
+  framing and high warning density (jamming/GPS-spoofing/licensing/Faraday-load).
+  `sdr_hacking.md` already had a dedicated legal notice — **added the missing
+  link to `LEGAL.md`** (the one gap).
+- **Links:** ✅ online check clean (0 errors).
+- **Verdict:** high quality; one legal-notice link added. **SDR review complete.**
+
 ### Repo-wide dead-link sweeps (2026-08-03)
 
 - **SANS `/blog/tag/*` link rot (systematic):** SANS reorganised their blog and

--- a/SDR/sdr_hacking.md
+++ b/SDR/sdr_hacking.md
@@ -19,7 +19,7 @@ Perform authorized RF security assessments against IoT, industrial, and wireless
 >
 > **Prerequisites assumed:** Linux proficiency, basic SDR/GNU Radio familiarity, security fundamentals. This guide extends (does not replaces) the General SDR.md section.
 >
-> **Legal notice:** All offensive techniques are presented for authorized security research, CTF competition, and defensive understanding only. Apply only against systems you own or have written authorization to test. RF transmission requires appropriate licensing.
+> **Legal notice:** All offensive techniques are presented for authorized security research, CTF competition, and defensive understanding only. Apply only against systems you own or have written authorization to test. RF transmission requires appropriate licensing. See [LEGAL.md](../LEGAL.md).
 
 ---
 


### PR DESCRIPTION
Per-domain review of the **SDR / RF** domain — the domain where safety framing matters most (unauthorized transmission is a federal offense; GPS/cellular spoofing endangers safety-of-life systems).

## Scope 2 — accuracy ✅

RF/regulatory claims check out (FCC framing, APRS 144.390 MHz, band references); tool references are current; `gr-gsm`'s upstream-unmaintained status is already noted.

## Scope 4 — safety ✅ (strong)

The domain treats RF transmission as the high-risk activity it is:
- `SDR/README.md` — prominent federal-offense transmission warning block
- `sdr.md` and `sdr_hacking.md` — early RF-safety framing, high warning density (jamming / GPS spoofing / licensing / Faraday load / dummy load)
- `sdr_hacking.md` already had a dedicated legal notice — **added the one missing piece: a link to `LEGAL.md`**

## Links ✅

Online link check clean (0 errors).

## Status

**SDR review complete** (4 domains done: IncidentResponse, Tradecraft, OSINT, SDR). Logged in the register; nothing removed. markdownlint clean; offline anchor check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)