### PR TITLE
audit(scope 11): resolve deprecated-tool contradictions (F-11)

### DIFF
--- a/AUDIT_FINDINGS.md
+++ b/AUDIT_FINDINGS.md
@@ -43,6 +43,7 @@ source; **Medium** = verified pattern but individual instances need a human call
 | F-08 | Medium | Duplication | Core topics duplicated across several root "master guide" docs with no canonical source | 6+ topics | High | ✅ Fixed (canonical cross-links) |
 | F-09 | Medium | Safety | Inconsistent prominence of the safety/authorization header on offensive docs | ~3 docs | Medium | ✅ Fixed |
 | F-10 | Low | Link hygiene | Dead/retired external links (scope 10, online sweep) | 4 fixed, 4 flagged | High | ✅ Fixed dead links; 4 flagged for manual review |
+| F-11 | Low | Contradiction | Deprecated tools recommended without caveat in some docs while flagged deprecated in others | 3 tools | High | ✅ Fixed (central GLOSSARY note + inline caveats) |
 
 *Findings F-08–F-09 come from the second audit pass (scope 2/4/11). The
 remediation approach for both lives in [AUDIT_REPORT.md](./AUDIT_REPORT.md)
@@ -291,6 +292,37 @@ each fix should be visually confirmed in GitHub's preview.*
   `STYLE_GUIDE.md` and apply it near the top of each offensive doc.
 - **Proposed action:** add the standard to the style guide, then apply per doc.
   This **adds** warnings/context; it removes nothing.
+
+---
+
+## F-11 — Deprecated tools referenced without caveat (scope 11, contradiction)
+
+- **Priority:** Low **Category:** Contradiction / consistency (scope 11) **Confidence:** High **Status:** ✅ Fixed
+- **Issue:** Three tools are flagged as deprecated in one authoritative place but
+  presented as current, without caveat, in other docs — a reader following the
+  latter would be misled. Severity varies by how broken each tool is:
+  - **CrackMapExec** — caveated in `README.md` and `Tradecraft/active-directory.md`,
+    but used without a note in ~10 other files (Homelab 14×, PlayBooks 7×,
+    advanced_techniques_part2 5×, ENHANCED 3×, Mobile SOP 3×, others). **Low
+    severity** — it is a maintained drop-in rename (`nxc`), so the commands still
+    work.
+  - **twint** — caveated in `Tradecraft/osint-threat-intel.md`, but listed in an
+    `ENHANCED_MASTER_GUIDE.md` install set without a note. **Higher severity** —
+    genuinely broken since X's 2023 API lockdown.
+  - **gr-gsm** — caveated in `SDR/sdr.md`, but listed without a note in
+    `SPECIALIZED_TOPICS_GUIDE.md` and `SDR/README.md` tables. **Higher severity** —
+    does not build on GNU Radio 3.10+.
+- **Fix (proportionate to severity):**
+  - Added a central **"Deprecated / Renamed Tooling"** section to `GLOSSARY.md`
+    covering all three — one authoritative, repo-wide status reference. This
+    resolves the CrackMapExec case centrally (a rename; per-line notes across 10
+    files would be noise).
+  - Added inline caveats to the genuinely-broken **gr-gsm** table rows in
+    `SPECIALIZED_TOPICS_GUIDE.md` and `SDR/README.md`.
+- **Not changed:** individual `crackmapexec` command examples (they work as `nxc`;
+  the GLOSSARY now states this), and the `twint` install-list line (mid-code-block;
+  covered by the GLOSSARY + the existing osint-threat-intel caveat).
+- **Verdict:** contradiction resolved; nothing removed.
 
 ---
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -55,6 +55,19 @@ A quick reference for acronyms and terms used across this repository. Terms are 
 - **SDR — Software-Defined Radio:** A radio whose signal processing is done in software (e.g., HackRF, RTL-SDR). See [SDR/](SDR/).
 - **Firmware:** The low-level software embedded in a device's non-volatile memory.
 
+## Deprecated / Renamed Tooling
+
+Repo-wide status notes for tools that appear across multiple guides. Where a guide
+still shows the old command, treat it per the note below.
+
+- **CrackMapExec (CME) → NetExec (`nxc`):** CrackMapExec was archived in 2023 and
+  continues as the maintained, **drop-in** NetExec — same syntax (run any
+  `crackmapexec …` example as `nxc …`).
+- **twint — broken:** stopped working after X/Twitter's 2023 API lockdown. Use
+  `snscrape` (non-Twitter modules) or official APIs instead.
+- **gr-gsm — unmaintained:** does not build on GNU Radio 3.10+. For cellular
+  research prefer `srsRAN` (srsLTE) or a maintained fork.
+
 ## Frameworks & Standards
 
 - **MITRE ATT&CK:** A knowledge base of adversary TTPs, referenced throughout the checklists. <https://attack.mitre.org>

--- a/SDR/README.md
+++ b/SDR/README.md
@@ -126,7 +126,7 @@ the Wiretap Act and ECPA.
 |--------|-------------|------------|
 | **[Replay Attack Scripts](https://github.com/greatscottgadgets/hackrf/tree/master/firmware/hackrf_usb)** | Capturing and rebroadcasting OOK/ASK signals | 🔴 HIGH |
 | **[GPS-SDR-SIM](https://github.com/osqzss/gps-sdr-sim)** | Generating fake GPS constellations for spoofing | 🔴 EXTREME |
-| **[gr-gsm](https://github.com/ptrkrysik/gr-gsm) / [srsLTE (srsRAN)](https://www.srsran.com/)** | Rogue base station / IMSI catcher frameworks | 🔴 EXTREME |
+| **[gr-gsm](https://github.com/ptrkrysik/gr-gsm) *(unmaintained; GNU Radio 3.10+)* / [srsRAN](https://www.srsran.com/)** | Rogue base station / IMSI catcher frameworks | 🔴 EXTREME |
 | **[RollJam (Sammy Kamkar)](https://samy.pl/rolljam/)** | Rolling code bypass implementation | 🔴 HIGH |
 | **[Jamming / Flooding](https://www.fcc.gov/general/jammer-enforcement)** | Overpowering legitimate RF receivers | 🔴 EXTREME |
 

--- a/SPECIALIZED_TOPICS_GUIDE.md
+++ b/SPECIALIZED_TOPICS_GUIDE.md
@@ -2161,7 +2161,7 @@ def analyze_iq_file(filename: str, sample_rate: float, center_freq: float):
 | **SatDump** | All | Satellite signal decoding suite |
 | **rtl_433** | All | ISM band device decoder (weather, TPMS, alarms) |
 | **dump1090** | All | ADS-B aircraft transponder decoder |
-| **gr-gsm** | Linux | GSM/cellular passive monitoring (research) |
+| **gr-gsm** | Linux | GSM/cellular passive monitoring (research) — ⚠️ unmaintained; won't build on GNU Radio 3.10+ (see [GLOSSARY](GLOSSARY.md#deprecated--renamed-tooling)) |
 | **kalibrate-rtl** | Linux | GSM base station frequency calibration |
 
 [Return to Table of Contents](#table-of-contents)


### PR DESCRIPTION
Scope 11 — **contradiction detection**. Found three tools flagged as deprecated in one authoritative place but recommended without caveat elsewhere (a reader following the latter would be misled).

## Findings (severity varies by how broken each tool is)

| Tool | Caveated in | Uncaveated in | Severity |
|------|-------------|---------------|----------|
| **CrackMapExec** | README, active-directory | ~10 files (Homelab 14×, PlayBooks 7×, part2 5×, …) | **Low** — maintained drop-in rename (`nxc`), commands still work |
| **twint** | osint-threat-intel | ENHANCED install set | **Higher** — genuinely broken since X's 2023 API lockdown |
| **gr-gsm** | sdr.md | SPECIALIZED + SDR/README tables | **Higher** — won't build on GNU Radio 3.10+ |

## Fix — proportionate to severity

- Added a central **"Deprecated / Renamed Tooling"** section to `GLOSSARY.md` covering all three — one authoritative, repo-wide status reference. This resolves the CrackMapExec case centrally (per-line notes across ~10 files would just be noise for a working rename).
- Added inline caveats to the genuinely-broken **gr-gsm** table rows in `SPECIALIZED_TOPICS_GUIDE.md` and `SDR/README.md`.

**Not changed:** individual `crackmapexec` examples (they run as `nxc`; the GLOSSARY now says so) and the `twint` install-list line (mid-code-block; covered by the GLOSSARY + the existing osint-threat-intel caveat). Nothing removed.

## Verification

- New GLOSSARY anchor references resolve (lychee `--include-fragments`: 0 errors)
- markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)