### PR TITLE
feat: add Web Application Security section (deliverable G — top gap)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -181,7 +181,7 @@ listed topic is **referenced in many files but lacks a dedicated section**.
 
 | Priority | Topic | Evidence | Proposed home |
 |----------|-------|----------|---------------|
-| High | **Web Application Security** | ~47 files mention it; no dedicated section | `WebAppSecurity/` (OWASP Top 10, Burp workflow, API testing) |
+| ✅ Done | **Web Application Security** | ~47 files mentioned it; no dedicated section | Delivered: [`WebAppSecurity/`](./WebAppSecurity/README.md) (OWASP Top 10:2025 deep-dive + full methodology) |
 | High | **Cloud Security** | ~42 files; only inside master guides | `Cloud/` (AWS/Azure/GCP attack + hardening) |
 | Medium | **Container & Kubernetes Security** | ~35 files; scattered | `Cloud/containers.md` or `ContainerSecurity/` |
 | Medium | **Cryptography** | ~24 files; only in cliff notes | `Documentation/cryptography.md` (primitives, TLS, hashing, PKI) |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 | 🚨 [Incident Response](IncidentResponse/) | Blue Team operations - threat detection, log aggregation, artifact analysis, standardized response procedures |
 | 📊 [SIEM Deployment Guides](IncidentResponse/SIEM/) | ELK Stack, Wazuh, Splunk, and Graylog setup and configuration |
 | 🔍 [OSINT Guide, Tools & Techniques](OSINT/OSINT_GUIDE.md) | Comprehensive OSINT methodology - 400+ categorized tools, investigation workflows, automated VM setup |
+| 🕸️ [Web Application Security](WebAppSecurity/) | OWASP Top 10 deep-dive and a full web app pentest methodology (recon, Burp workflow, injection/access-control/API testing) |
 | 🔴 [OPSEC](OPSEC/) | Operational security practices - anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 [Homelab Guides](Homelab/) | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🤖 [AI Cybersecurity Resources](AI/README.md) | Self-hosted AI agents (OpenClaw, AnythingLLM), LLM prompting for security, offline AI deployment, AI-powered security workflows |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -25,6 +25,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 - **Blue Team / SOC?** → [Incident Response](IncidentResponse/) + [Blue Team Playbooks](PlayBooks/) + [SIEM Guides](IncidentResponse/SIEM/)
 - **OSINT Investigator?** → [OSINT Guide](OSINT/OSINT_GUIDE.md) + [Tradecraft/OSINT Threat Intel](Tradecraft/osint-threat-intel.md)
 - **Red Team Operator?** → [Tradecraft](Tradecraft/) + [Advanced Techniques](advanced_techniques_supplement.md) + [Scripts](Scripts/)
+- **Web App Pentester?** → [Web Application Security](WebAppSecurity/) ([OWASP Top 10](WebAppSecurity/owasp-top-10.md) + [Methodology](WebAppSecurity/methodology.md))
 - **Hardware Hacker?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts II–III) + [Enhanced Master Guide](ENHANCED_MASTER_GUIDE.md) + [Firmware & Hardware Compatibility](firmware-hardware-compatibility.md)
 - **AI / LLM Security?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Part I) + [AI Resources](AI/README.md)
 - **SDR / RF / Space?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts V–VI) + [SDR](SDR/) + [SpaceSecurity](SpaceSecurity/)
@@ -87,6 +88,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 | 📋 **[Operational Playbooks](PlayBooks/cybersecurity_playbooks.md)** | Field-ready playbooks for professional network & WiFi security audits and pentests |
 | 🔍 **[OSINT Guide, Tools & Techniques](OSINT/OSINT_GUIDE.md)** | Comprehensive OSINT methodology; 400+ categorized tools, investigation workflows |
 | 🕵️ **[Tradecraft](Tradecraft/)** | Offensive tradecraft; AD attacks, C2 frameworks, AV/EDR evasion, LOLBins, network detection evasion, threat intel |
+| 🕸️ **[Web Application Security](WebAppSecurity/)** | OWASP Top 10 deep-dive and web app pentest methodology (Burp workflow, injection/access-control/API testing) |
 | 🔴 **[OPSEC](OPSEC/)** | Operational security; anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 **[Homelab Guides](Homelab/)** | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🚨 **[Incident Response](IncidentResponse/)** | Blue Team operations; threat detection, log aggregation, artifact analysis, SIEM setup |

--- a/WebAppSecurity/README.md
+++ b/WebAppSecurity/README.md
@@ -1,0 +1,140 @@
+# 🕸️ Web Application Security
+
+<div align="center">
+
+**Methodology, OWASP Top 10, and tooling for authorized web application security assessment**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../README.md)*
+
+![Focus](https://img.shields.io/badge/Focus-Web_AppSec-blue?style=for-the-badge)
+![OWASP](https://img.shields.io/badge/OWASP-Top_10-orange?style=for-the-badge)
+![Use](https://img.shields.io/badge/Use-Authorized_Only-red?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Dedicated home for web application security - the OWASP Top 10, a repeatable
+assessment methodology, and the tooling (Burp Suite, API/GraphQL testing) used to
+find and fix web vulnerabilities during authorized engagements.
+
+## ⚙️ Function
+Indexes the Web Application Security section: an OWASP Top 10 deep-dive (2025
+Release Candidate, mapped to 2021) and a full web application penetration testing
+methodology covering reconnaissance, mapping, the Burp Suite workflow, injection
+and access-control testing, business-logic flaws, and API/GraphQL testing - each
+paired with defensive guidance.
+
+## 🏆 Goal
+Give practitioners a single canonical web-AppSec reference: understand each risk
+class, test for it methodically, and remediate it - rather than the web content
+being scattered across the master guides.
+
+## 📋 When to Use
+- Scoping or executing an authorized web application penetration test
+- Looking up a specific OWASP Top 10 category (how it works, how to test, how to fix)
+- Building a repeatable methodology / Burp workflow for web assessments
+- Reviewing a web app or API defensively against the current OWASP risks
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#-overview)
+- [Folder Contents](#-folder-contents)
+- [Testing Approach](#-testing-approach)
+- [Security & Legal Disclaimer](#-security--legal-disclaimer)
+- [Related Sections](#-related-sections)
+- [Resources](#-resources)
+
+---
+
+## 🎯 Overview
+
+Web applications are the most exposed part of most organizations' attack surface,
+and web AppSec is one of the most frequently referenced topics across this
+repository - but it previously had no dedicated home. This section consolidates
+it: what the current risks are, how to test for them, and how to defend.
+
+The material is **dual-use** - every risk class pairs the offensive perspective
+(how it is found and exploited) with the defensive one (how to prevent and detect
+it), mirroring the [Tradecraft](../Tradecraft/) convention.
+
+---
+
+## 📂 Folder Contents
+
+| File | Description | Status |
+|------|-------------|--------|
+| **[owasp-top-10.md](./owasp-top-10.md)** | OWASP Top 10:2025 (RC) deep-dive - each category with exploitation, testing, and defense, plus a 2021→2025 mapping | ✅ Complete |
+| **[methodology.md](./methodology.md)** | Web app pentest methodology: recon, mapping, Burp Suite workflow, injection/access-control/business-logic testing, API & GraphQL testing, reporting | ✅ Complete |
+
+---
+
+## 🧭 Testing Approach
+
+A web assessment generally proceeds in phases (detailed in
+[methodology.md](./methodology.md)):
+
+1. **Recon & mapping** - enumerate content, endpoints, technologies, and roles.
+2. **Configuration & deployment** - TLS, headers, exposed files, default creds.
+3. **Authentication & session** - login flaws, session handling, MFA, JWT.
+4. **Authorization** - horizontal/vertical access control (the #1 risk class).
+5. **Input handling** - injection (SQLi, command, template), XSS, deserialization.
+6. **Business logic** - abuse of legitimate functionality and workflows.
+7. **APIs** - REST and GraphQL-specific testing.
+8. **Reporting** - reproducible findings mapped to OWASP / CWE with remediation.
+
+---
+
+## ⚠️ Security & Legal Disclaimer
+
+> [!CAUTION]
+> **Authorized use only.** The techniques here are for authorized penetration
+> testing, education, and defensive research. Testing a web application you do not
+> own or lack **explicit written permission** to assess is illegal (e.g. the U.S.
+> Computer Fraud and Abuse Act and equivalents elsewhere). Always work within a
+> signed scope and rules of engagement. See [LEGAL.md](../LEGAL.md).
+
+---
+
+## 🔗 Related Sections
+
+- [`/Tradecraft`](../Tradecraft/) - Offensive/defensive deep-dives (AD, C2, evasion) that pair with web AppSec
+- [`/Checklists`](../Checklists/) - Quick-reference assessment checklists
+- [`/OSINT`](../OSINT/) - Reconnaissance that precedes a web assessment
+- [`/Scripts`](../Scripts/) - Automation and payload references
+- [`ultimate_cybersecurity_master_guide.md`](../ultimate_cybersecurity_master_guide.md) - Web Application Reconnaissance / Vulnerabilities (summary sections)
+- [`advanced_techniques_part2.md`](../advanced_techniques_part2.md) - Advanced Web Application Attacks
+
+---
+
+## 📚 Resources
+
+- [OWASP Top 10](https://owasp.org/Top10/) - the current risk list (2025 RC; 2021 stable)
+- [OWASP Web Security Testing Guide (WSTG)](https://owasp.org/www-project-web-security-testing-guide/) - the definitive testing methodology
+- [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) - verifiable security requirements
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/) - concise defensive guidance per topic
+- [PortSwigger Web Security Academy](https://portswigger.net/web-security) - free, hands-on labs
+- [MITRE CWE](https://cwe.mitre.org/) - weakness taxonomy referenced by findings
+
+---
+
+<div align="center">
+
+**⚠️ USE THIS REPO RESPONSIBLY AND LEGALLY ⚠️**
+
+**Repository**: [ULTIMATE CYBERSECURITY MASTER GUIDE](https://github.com/Pnwcomputers/ULTIMATE-CYBERSECURITY-MASTER-GUIDE)
+
+**Maintained by**: [Pacific Northwest Computers](https://github.com/Pnwcomputers)
+
+</div>
+
+---
+
+## Related Files
+- [owasp-top-10.md](owasp-top-10.md) - OWASP Top 10:2025 deep-dive with testing and defense
+- [methodology.md](methodology.md) - Web application penetration testing methodology
+- [../GLOSSARY.md](../GLOSSARY.md) - Acronyms and terms (OWASP, CWE, SSRF, XSS…)
+- [../LEGAL.md](../LEGAL.md) - Legal notice and authorized-use terms

--- a/WebAppSecurity/methodology.md
+++ b/WebAppSecurity/methodology.md
@@ -1,0 +1,228 @@
+# 🧭 Web Application Penetration Testing Methodology
+
+> [!CAUTION]
+> **Authorized use only.** This methodology is for authorized penetration testing,
+> education, and defensive research. Only test applications you own or have
+> **explicit written permission** and a signed scope to assess. See
+> [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+A repeatable, phase-by-phase methodology for authorized web application assessments -
+from scoping through reporting - aligned with the OWASP Web Security Testing Guide.
+
+## ⚙️ Function
+Covers pre-engagement scoping, reconnaissance and mapping, a practical Burp Suite
+workflow, configuration/authentication/authorization/input/business-logic testing,
+API and GraphQL testing, and reporting. Complements the
+[OWASP Top 10 deep-dive](owasp-top-10.md), which details the individual risk classes.
+
+## 🏆 Goal
+Enable a tester to run a consistent, thorough web assessment that maps findings to
+OWASP/CWE with reproducible evidence and actionable remediation.
+
+## 📋 When to Use
+- Executing an authorized web application or API penetration test
+- Standardizing a team's web testing workflow and tooling
+- Preparing a scoped methodology for a client engagement
+
+---
+
+## 📋 Table of Contents
+
+- [Phase 0: Scoping & Rules of Engagement](#phase-0-scoping--rules-of-engagement)
+- [Phase 1: Reconnaissance & Mapping](#phase-1-reconnaissance--mapping)
+- [Phase 2: Burp Suite Workflow](#phase-2-burp-suite-workflow)
+- [Phase 3: Configuration & Deployment Testing](#phase-3-configuration--deployment-testing)
+- [Phase 4: Authentication & Session Testing](#phase-4-authentication--session-testing)
+- [Phase 5: Authorization Testing](#phase-5-authorization-testing)
+- [Phase 6: Input & Injection Testing](#phase-6-input--injection-testing)
+- [Phase 7: Business Logic Testing](#phase-7-business-logic-testing)
+- [Phase 8: API & GraphQL Testing](#phase-8-api--graphql-testing)
+- [Phase 9: Reporting](#phase-9-reporting)
+- [Tooling Reference](#-tooling-reference)
+- [Resources](#-resources)
+
+---
+
+## Phase 0: Scoping & Rules of Engagement
+
+Before any traffic is sent:
+
+- Confirm **written authorization**, in-scope hosts/domains, and excluded targets.
+- Agree testing windows, rate limits, and whether destructive tests (e.g. DoS,
+  mass data modification) are permitted (usually **not**).
+- Identify test accounts (ideally two per role for access-control testing).
+- Establish an emergency contact and a stop condition.
+- Record everything - scope defines what is legal to touch. See
+  [LEGAL.md](../LEGAL.md) and the [OSINT Playbook](../OSINT/Playbook/README.md)
+  for engagement-documentation patterns.
+
+---
+
+## Phase 1: Reconnaissance & Mapping
+
+Build a complete picture of the application before testing it.
+
+- **Passive:** technology fingerprinting (Wappalyzer, response headers), subdomain
+  and content discovery, JS review for endpoints and secrets. See
+  [OSINT/scripts/Domain_IP_Recon.md](../OSINT/scripts/Domain_IP_Recon.md).
+- **Active:** spider/crawl the app, enumerate directories and parameters
+  (`ffuf`, `feroxbuster`), map every role's reachable functionality.
+- **Output:** an endpoint/parameter inventory and a per-role functionality map -
+  the input to every later phase.
+
+```bash
+# Content discovery (authorized scope only)
+ffuf -u https://TARGET/FUZZ -w wordlist.txt -mc 200,204,301,302,401,403
+feroxbuster -u https://TARGET -w wordlist.txt
+
+# Passive tech/endpoint hints
+curl -sI https://TARGET            # headers: server, framework, security headers
+```
+
+---
+
+## Phase 2: Burp Suite Workflow
+
+Burp Suite (Community or Professional) is the core interception proxy.
+
+1. **Proxy setup:** route the browser through Burp; install Burp's CA cert for TLS.
+2. **Target scope:** set scope to in-scope hosts so tooling never strays.
+3. **Crawl & map:** browse the app to populate the site map; review every request.
+4. **Repeater:** manually manipulate individual requests to probe behavior.
+5. **Intruder:** automate payload injection (fuzzing, brute force) within scope.
+6. **Decoder / Comparer:** encode/decode data and diff responses.
+7. **Extensions (BApp Store):** *Autorize*/*Auth Analyzer* (access control),
+   *Logger++*, *JWT Editor*, *Param Miner*, *Active Scan++*.
+8. **Scanner (Pro):** automated scanning to complement - not replace - manual testing.
+
+> [!TIP]
+> Automated scanners find the easy issues; access-control and business-logic flaws
+> almost always require manual testing with two accounts and an understanding of the
+> app's intent.
+
+---
+
+## Phase 3: Configuration & Deployment Testing
+
+Maps to [A02 Security Misconfiguration](owasp-top-10.md#a02-security-misconfiguration)
+and [A04 Cryptographic Failures](owasp-top-10.md#a04-cryptographic-failures).
+
+- TLS configuration and certificate validity; HSTS.
+- Security headers: CSP, `X-Content-Type-Options`, `Referrer-Policy`, frame options.
+- Exposed files: `.git/`, backups, `/actuator`, `.env`, source maps, admin consoles.
+- CORS policy (test with a rogue `Origin`); cookie flags (`HttpOnly`, `Secure`, `SameSite`).
+- Default credentials on any administrative surface.
+
+---
+
+## Phase 4: Authentication & Session Testing
+
+Maps to [A07 Authentication Failures](owasp-top-10.md#a07-authentication-failures).
+
+- Login: rate limiting / lockout, username enumeration, credential stuffing exposure.
+- Password reset and MFA flows for bypasses and information leaks.
+- Session lifecycle: fixation, rotation on privilege change, invalidation on logout,
+  idle/absolute expiry.
+- Tokens/JWT: validate `alg` and signature server-side; check for `alg:none`, weak
+  secrets, missing expiry, and sensitive claims.
+
+---
+
+## Phase 5: Authorization Testing
+
+Maps to [A01 Broken Access Control](owasp-top-10.md#a01-broken-access-control) - the
+highest-prevalence risk, and the phase automation misses most.
+
+- **Horizontal:** with two same-role accounts, replay each user's requests as the
+  other; increment/swap object identifiers (IDOR).
+- **Vertical:** attempt admin/privileged functionality as a low-privileged user;
+  request privileged endpoints directly (forced browsing).
+- **Method/param tampering:** change HTTP verbs, toggle role parameters, remove
+  authorization headers.
+- Use Burp *Autorize*/*Auth Analyzer* to systematize the two-account replay.
+
+---
+
+## Phase 6: Input & Injection Testing
+
+Maps to [A05 Injection](owasp-top-10.md#a05-injection).
+
+- Fuzz every input surface (query/body/path/headers/JSON) with context-specific
+  payloads; observe reflected, stored, and DOM contexts for XSS.
+- SQL/NoSQL injection: confirm manually, then `sqlmap` within scope.
+- Command and template injection (SSTI); LDAP/XPath where applicable.
+- File upload: type/content validation, path traversal, dangerous extensions.
+
+```bash
+# SQL injection confirmation (authorized scope only)
+sqlmap -u "https://TARGET/item?id=1" --batch --risk=1 --level=1
+# note: coordinate risk/level and data-modifying options with the ROE
+```
+
+---
+
+## Phase 7: Business Logic Testing
+
+Maps to [A06 Insecure Design](owasp-top-10.md#a06-insecure-design). These flaws
+abuse legitimate functionality and require understanding the app's intent.
+
+- Workflow bypasses (skip steps, replay, out-of-order requests).
+- Value/quantity tampering (negative amounts, price manipulation, coupon reuse).
+- Missing anti-automation on sensitive actions (OTP, reset, checkout).
+- Race conditions on state-changing operations (concurrent requests).
+
+---
+
+## Phase 8: API & GraphQL Testing
+
+APIs are a major modern attack surface (see the OWASP API Security Top 10).
+
+- **REST:** enumerate endpoints (Swagger/OpenAPI if exposed); test object- and
+  function-level authorization (BOLA/BFLA - the API analogue of A01); mass
+  assignment; excessive data exposure; rate limiting.
+- **GraphQL:** attempt introspection to map the schema; test authorization per
+  resolver; watch for nested-query/batching abuse (DoS) and injection via arguments.
+- Tooling: Burp, Postman, `graphql-cog`/`clairvoyance` (introspection), and the
+  [OWASP API Security Top 10](https://owasp.org/API-Security/).
+
+---
+
+## Phase 9: Reporting
+
+- Each finding: title, severity (with CVSS where useful), affected endpoint,
+  reproducible steps/evidence, impact, and **remediation**.
+- Map findings to [OWASP Top 10](owasp-top-10.md) categories and CWE IDs.
+- Separate confirmed vulnerabilities from informational/hardening observations.
+- Provide an executive summary and a prioritized remediation roadmap.
+
+---
+
+## 🛠️ Tooling Reference
+
+| Tool | Role |
+|------|------|
+| [Burp Suite](https://portswigger.net/burp) | Interception proxy, repeater, intruder, scanner |
+| [OWASP ZAP](https://www.zaproxy.org/) | Open-source proxy/scanner alternative |
+| [ffuf](https://github.com/ffuf/ffuf) / [feroxbuster](https://github.com/epi052/feroxbuster) | Content & parameter discovery |
+| [sqlmap](https://sqlmap.org/) | SQL injection confirmation/exploitation |
+| [nuclei](https://github.com/projectdiscovery/nuclei) | Template-based vulnerability scanning |
+| [Postman](https://www.postman.com/) | API request crafting |
+| [jwt_tool](https://github.com/ticarpi/jwt_tool) | JWT analysis and attacks |
+
+---
+
+## 📚 Resources
+
+- [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/) - the definitive methodology
+- [OWASP API Security Top 10](https://owasp.org/API-Security/) - API-specific risks
+- [OWASP ASVS](https://owasp.org/www-project-application-security-verification-standard/) - verification requirements
+- [PortSwigger Web Security Academy](https://portswigger.net/web-security) - hands-on labs
+
+---
+
+## Related Files
+- [README.md](README.md) - Web Application Security section index
+- [owasp-top-10.md](owasp-top-10.md) - the risk classes this methodology tests for
+- [../OSINT/scripts/Domain_IP_Recon.md](../OSINT/scripts/Domain_IP_Recon.md) - recon that feeds Phase 1
+- [../IncidentResponse/SIEM/README.md](../IncidentResponse/SIEM/README.md) - the defensive/detection side

--- a/WebAppSecurity/owasp-top-10.md
+++ b/WebAppSecurity/owasp-top-10.md
@@ -1,0 +1,274 @@
+# 🔟 OWASP Top 10 - Deep Dive
+
+> [!CAUTION]
+> **Authorized use only.** The exploitation techniques below are for authorized
+> testing, education, and defensive research. Testing systems you do not own or
+> lack explicit written permission to assess is illegal. See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+A working reference for the OWASP Top 10 web application risks - each category
+covering what it is, how it is exploited, how to test for it, and how to defend
+against it.
+
+## ⚙️ Function
+Walks all ten categories of the **OWASP Top 10:2025** (Release Candidate), with a
+mapping back to the stable **2021** list. Each entry pairs offensive testing notes
+with defensive controls and links to the relevant OWASP Cheat Sheet.
+
+## 🏆 Goal
+Let a reader look up any Top 10 category and immediately know how it manifests,
+how to test for it in an authorized engagement, and what remediation to recommend.
+
+## 📋 When to Use
+- Testing a web application against a specific risk class
+- Writing a finding and needing the OWASP/CWE mapping plus remediation guidance
+- Reviewing an application or design defensively against the current risk list
+
+---
+
+## 📋 Table of Contents
+
+- [Version Note: 2025 RC vs 2021](#-version-note-2025-rc-vs-2021)
+- [A01: Broken Access Control](#a01-broken-access-control)
+- [A02: Security Misconfiguration](#a02-security-misconfiguration)
+- [A03: Software Supply Chain Failures](#a03-software-supply-chain-failures)
+- [A04: Cryptographic Failures](#a04-cryptographic-failures)
+- [A05: Injection](#a05-injection)
+- [A06: Insecure Design](#a06-insecure-design)
+- [A07: Authentication Failures](#a07-authentication-failures)
+- [A08: Software or Data Integrity Failures](#a08-software-or-data-integrity-failures)
+- [A09: Security Logging and Alerting Failures](#a09-security-logging-and-alerting-failures)
+- [A10: Mishandling of Exceptional Conditions](#a10-mishandling-of-exceptional-conditions)
+- [2021 to 2025 Mapping](#2021-to-2025-mapping)
+- [Resources](#-resources)
+
+---
+
+## 🗓️ Version Note: 2025 RC vs 2021
+
+At the time of writing, **OWASP Top 10:2025 is a Release Candidate** and
+**2021 is the last finalized edition**. This guide follows the 2025 ordering and
+category names (verified against <https://owasp.org/Top10/2025/>) because it
+reflects current data, and provides a [2021→2025 mapping](#2021-to-2025-mapping)
+so findings written against either edition line up. Confirm the current status at
+<https://owasp.org/Top10/> before citing an edition in a formal report.
+
+Two structural changes in 2025 are worth noting:
+
+- **A03: Software Supply Chain Failures** broadens 2021's "Vulnerable and Outdated
+  Components" to cover the whole dependency/build/distribution chain.
+- **A10: Mishandling of Exceptional Conditions** is new, covering error-handling
+  and fail-open logic (SSRF from 2021's A10 folds into Broken Access Control /
+  Server-Side Request areas).
+
+---
+
+## A01: Broken Access Control
+
+The most prevalent risk in both 2021 and 2025. The application fails to enforce
+what an authenticated user is allowed to do.
+
+- **How it is exploited:** changing an identifier to access another user's data
+  (IDOR / horizontal), reaching admin functionality as a normal user (vertical),
+  forced browsing to unlinked endpoints, or tampering with a JWT/cookie role claim.
+- **How to test:** with two accounts of different privilege, replay each request
+  as the other (Burp's *Autorize*/*Auth Analyzer* extensions help); enumerate
+  object IDs; request admin routes directly; verify server-side enforcement rather
+  than hidden-in-the-UI controls.
+- **How to defend:** deny by default; enforce authorization **server-side** on
+  every request against the authenticated principal; use opaque/unguessable
+  references or ownership checks; centralize access-control logic; log failures.
+- **CWE:** CWE-284, CWE-639, CWE-862. **Cheat sheet:** [Authorization](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html).
+
+---
+
+## A02: Security Misconfiguration
+
+Insecure defaults, incomplete hardening, verbose errors, and unnecessary features.
+
+- **How it is exploited:** default/administrative credentials, exposed admin
+  consoles or `.git`/backup files, missing security headers, directory listing,
+  overly permissive CORS, verbose stack traces revealing internals.
+- **How to test:** enumerate exposed paths and files; review response headers
+  (CSP, HSTS, `X-Content-Type-Options`); check CORS with a rogue `Origin`; probe
+  default credentials on any admin surface; diff against a hardening baseline.
+- **How to defend:** a repeatable hardening process; remove unused features and
+  sample apps; set security headers; suppress verbose errors in production; keep
+  environments consistent; automate configuration checks.
+- **CWE:** CWE-16, CWE-548. **Cheat sheet:** [OWASP Secure Headers](https://owasp.org/www-project-secure-headers/).
+
+---
+
+## A03: Software Supply Chain Failures
+
+Expanded in 2025 from "Vulnerable and Outdated Components" to the whole chain:
+dependencies, build pipelines, and distribution.
+
+- **How it is exploited:** known-vulnerable libraries (n-day), typosquatted or
+  compromised packages, poisoned build/CI steps, unsigned artifacts, or a
+  compromised update channel (cf. the SolarWinds and `xz`/CVE-2024-3094 cases).
+- **How to test:** inventory dependencies (SBOM); run SCA against known-CVE
+  databases; check for pinned, integrity-verified dependencies; review CI/CD trust
+  boundaries and who can publish artifacts.
+- **How to defend:** maintain an SBOM; pin and verify dependencies (hashes/lock
+  files); use signed artifacts and provenance (e.g. SLSA, Sigstore); restrict and
+  monitor the build pipeline; patch promptly.
+- **CWE:** CWE-1104, CWE-1357. **Cheat sheet:** [Vulnerable Dependency Management](https://cheatsheetseries.owasp.org/cheatsheets/Vulnerable_Dependency_Management_Cheat_Sheet.html).
+
+---
+
+## A04: Cryptographic Failures
+
+Weak, misused, or missing cryptography that exposes data in transit or at rest.
+
+- **How it is exploited:** cleartext transport, weak/deprecated ciphers or hashes
+  (MD5, SHA-1, ECB), hard-coded or reused keys, missing encryption of sensitive
+  data, predictable IVs/nonces, unsalted password hashes.
+- **How to test:** check TLS configuration and certificate validity; look for
+  sensitive data sent or stored in cleartext; review password storage
+  (algorithm/salt); inspect for hard-coded secrets; verify token/randomness quality.
+- **How to defend:** enforce TLS (HSTS); use vetted algorithms (AES-GCM,
+  ChaCha20-Poly1305; Argon2/bcrypt/scrypt for passwords); manage keys in a KMS/HSM;
+  classify data and encrypt sensitive fields; never roll your own crypto.
+- **CWE:** CWE-259, CWE-327, CWE-331. **Cheat sheet:** [Cryptographic Storage](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html).
+
+---
+
+## A05: Injection
+
+Untrusted input is interpreted as code or a command. Includes SQL, NoSQL, OS
+command, LDAP, and (server-side) template injection, plus cross-site scripting.
+
+- **How it is exploited:** breaking out of a query/command context - `' OR 1=1--`
+  (SQLi), `{{7*7}}` (SSTI), backtick/`;` chaining (command injection), or reflected
+  /stored/DOM **XSS** injecting script into a page.
+- **How to test:** fuzz every input (params, headers, JSON, path) with
+  context-specific payloads; use Burp Intruder/Scanner; confirm SQLi with `sqlmap`
+  in scope; test XSS across reflected, stored, and DOM sinks.
+- **How to defend:** parameterized queries / prepared statements; safe ORMs;
+  context-aware output encoding and a strong Content-Security-Policy for XSS;
+  allow-list input validation; avoid passing input to shells/interpreters.
+- **CWE:** CWE-89, CWE-79, CWE-78, CWE-94. **Cheat sheets:** [Injection Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html), [XSS Prevention](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html).
+
+---
+
+## A06: Insecure Design
+
+Flaws in the design itself - missing or ineffective controls that no amount of
+clean implementation can fix.
+
+- **How it is exploited:** abusing a workflow that was never threat-modeled - e.g.
+  no rate limiting on a password-reset or OTP flow, trusting client-side controls,
+  or a recovery process that leaks information.
+- **How to test:** threat-model the feature; look for missing anti-automation,
+  trust-boundary violations, and assumptions the client can break; test negative
+  and abuse cases, not just the happy path.
+- **How to defend:** threat modeling in design; secure design patterns and
+  reference architectures; establish trust boundaries; write abuse/misuse cases and
+  test them; apply defense in depth.
+- **CWE:** CWE-73, CWE-602, CWE-657. **Cheat sheet:** [Threat Modeling](https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html).
+
+---
+
+## A07: Authentication Failures
+
+Weaknesses in confirming identity and managing sessions.
+
+- **How it is exploited:** credential stuffing and brute force (no lockout/rate
+  limit), weak password policies, session fixation, exposed or non-expiring session
+  tokens, flawed MFA, and weak JWT handling (`alg:none`, weak secret, no expiry).
+- **How to test:** probe login for lockout/rate limiting; test session lifecycle
+  (fixation, invalidation on logout, rotation); inspect JWTs (algorithm, signature,
+  expiry, claims); test password reset and MFA bypasses.
+- **How to defend:** rate limiting and lockout; MFA; strong password storage
+  (Argon2/bcrypt) and breached-password checks; secure, `HttpOnly`, `SameSite`
+  session cookies with rotation and expiry; validate JWT `alg` and signature server-side.
+- **CWE:** CWE-287, CWE-384, CWE-613. **Cheat sheet:** [Authentication](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html).
+
+---
+
+## A08: Software or Data Integrity Failures
+
+Code or data trusted without verifying integrity - including insecure
+deserialization and unverified updates.
+
+- **How it is exploited:** insecure deserialization leading to RCE, unsigned or
+  unverified auto-updates, CI/CD that trusts untrusted input, or client-side
+  integrity assumptions (no Subresource Integrity on third-party scripts).
+- **How to test:** identify serialized objects crossing trust boundaries; test
+  deserialization with known gadget chains (in scope); check update mechanisms for
+  signature verification; look for missing SRI on external resources.
+- **How to defend:** avoid native deserialization of untrusted data (use data-only
+  formats with schema validation); sign and verify updates and artifacts; enforce
+  integrity in CI/CD; use Subresource Integrity for third-party scripts.
+- **CWE:** CWE-502, CWE-345, CWE-829. **Cheat sheet:** [Deserialization](https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html).
+
+---
+
+## A09: Security Logging and Alerting Failures
+
+Insufficient logging, monitoring, and alerting - which lets attacks proceed
+undetected. (2021: "Logging and Monitoring Failures".)
+
+- **How it is exploited:** not a direct exploit but an amplifier - failed logins,
+  access-control denials, and input-validation failures go unlogged, so intrusions
+  are neither detected nor investigable.
+- **How to test:** verify security-relevant events are logged (authn/authz
+  failures, high-value actions); confirm logs are tamper-resistant and shipped off
+  host; check that alerts actually fire on suspicious patterns.
+- **How to defend:** log security events with enough context; centralize logs to a
+  [SIEM](../IncidentResponse/SIEM/README.md); protect log integrity; define and
+  test alerting; align retention with response needs.
+- **CWE:** CWE-778, CWE-223. **Cheat sheet:** [Logging](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html).
+
+---
+
+## A10: Mishandling of Exceptional Conditions
+
+New in 2025: error-handling and edge-case logic that fails insecurely.
+
+- **How it is exploited:** fail-open logic (an error path that grants access),
+  inconsistent state after a partial failure, information disclosure through error
+  messages, or race conditions in exceptional paths.
+- **How to test:** force error and edge conditions (malformed input, timeouts,
+  concurrent requests); observe whether failures fail **open** or closed; check
+  error responses for leaked internals; test race conditions on state-changing ops.
+- **How to defend:** fail closed by default; handle errors explicitly and
+  uniformly; avoid leaking internals in messages; make state changes atomic; test
+  exceptional paths as first-class scenarios.
+- **CWE:** CWE-755, CWE-209, CWE-362. **Cheat sheet:** [Error Handling](https://cheatsheetseries.owasp.org/cheatsheets/Error_Handling_Cheat_Sheet.html).
+
+---
+
+## 2021 to 2025 Mapping
+
+| 2021 | 2025 |
+|------|------|
+| A01 Broken Access Control | A01 Broken Access Control |
+| A02 Cryptographic Failures | A04 Cryptographic Failures |
+| A03 Injection | A05 Injection |
+| A04 Insecure Design | A06 Insecure Design |
+| A05 Security Misconfiguration | A02 Security Misconfiguration |
+| A06 Vulnerable and Outdated Components | A03 Software Supply Chain Failures (expanded) |
+| A07 Identification and Authentication Failures | A07 Authentication Failures |
+| A08 Software and Data Integrity Failures | A08 Software or Data Integrity Failures |
+| A09 Security Logging and Monitoring Failures | A09 Security Logging and Alerting Failures |
+| A10 Server-Side Request Forgery (SSRF) | folded into A01 / server-side request areas |
+| *(new in 2025)* | A10 Mishandling of Exceptional Conditions |
+
+---
+
+## 📚 Resources
+
+- [OWASP Top 10](https://owasp.org/Top10/) - authoritative source (check current edition)
+- [OWASP Web Security Testing Guide](https://owasp.org/www-project-web-security-testing-guide/) - how to test each category
+- [OWASP Cheat Sheet Series](https://cheatsheetseries.owasp.org/) - defensive guidance per topic
+- [MITRE CWE](https://cwe.mitre.org/) - weakness identifiers used above
+- [PortSwigger Web Security Academy](https://portswigger.net/web-security) - hands-on labs per vulnerability class
+
+---
+
+## Related Files
+- [README.md](README.md) - Web Application Security section index
+- [methodology.md](methodology.md) - the assessment workflow that applies these categories
+- [../GLOSSARY.md](../GLOSSARY.md) - Acronyms (OWASP, CWE, SSRF, XSS, SSTI…)

--- a/advanced_techniques_part2.md
+++ b/advanced_techniques_part2.md
@@ -1075,6 +1075,10 @@ api_call = deobfuscate_string("Gx4bHRsd")  # "VirtualAlloc"
 
 ## Advanced Web Application Attacks
 
+> [!NOTE]
+> **Canonical reference:** for OWASP Top 10 and full methodology see the dedicated
+> [WebAppSecurity/](WebAppSecurity/README.md) section. This covers advanced attacks.
+
 ### Server-Side Template Injection (SSTI)
 
 #### Detection

--- a/ultimate_cybersecurity_master_guide.md
+++ b/ultimate_cybersecurity_master_guide.md
@@ -624,6 +624,11 @@ smbclient //192.168.1.100/share -U username
 
 ## Web Application Reconnaissance
 
+> [!NOTE]
+> **Canonical reference:** the dedicated web section is
+> [WebAppSecurity/](WebAppSecurity/README.md) - OWASP Top 10 deep-dive and a full
+> testing methodology. This section is a summary.
+
 ### Directory & File Enumeration
 ```bash
 # Gobuster


### PR DESCRIPTION
Builds the **highest-priority coverage gap** from the audit's Content Expansion Plan (deliverable G): web AppSec was referenced in ~47 files but had no dedicated home. New `WebAppSecurity/` section, in the repo's house style.

## New content

| File | What it covers |
|------|----------------|
| `README.md` | Section index — Purpose/Function/Goal, TOC, testing approach, legal disclaimer, resources |
| `owasp-top-10.md` | **OWASP Top 10:2025 (RC)** deep-dive — each category with exploitation, testing, and defense — plus a 2021→2025 mapping |
| `methodology.md` | Full web pentest methodology — scoping, recon, **Burp Suite workflow**, config/auth/authz/injection/business-logic testing, **API & GraphQL**, reporting |

## Accuracy

The OWASP categories were **verified against `owasp.org/Top10/2025`** (not written from memory) — 2025 is the current Release Candidate, 2021 the last stable, and the guide states this explicitly and maps between them. Notably captures the 2025 changes (A03 Software Supply Chain Failures, A10 Mishandling of Exceptional Conditions).

## Wiring & consistency

- Listed in `README.md` and `START_HERE.md`; added a **"Web App Pentester?"** role path
- **Canonical cross-links** (F-08 pattern) from the master guides' web sections to the new section
- Every doc carries the **F-09 authorization header**; dual-use (attack + defense) structure like Tradecraft
- Marked the Web App gap **Done** in `AUDIT_REPORT.md`

## Verification

- **All 111 links verified live online** (OWASP cheat sheets, PortSwigger, CWE, tooling) — 0 errors
- Anchors resolve (`--include-fragments`); markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)