### PR TITLE
feat: add Cloud Security section (deliverable G gap)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -182,7 +182,7 @@ listed topic is **referenced in many files but lacks a dedicated section**.
 | Priority | Topic | Evidence | Proposed home |
 |----------|-------|----------|---------------|
 | ✅ Done | **Web Application Security** | ~47 files mentioned it; no dedicated section | Delivered: [`WebAppSecurity/`](./WebAppSecurity/README.md) (OWASP Top 10:2025 deep-dive + full methodology) |
-| High | **Cloud Security** | ~42 files; only inside master guides | `Cloud/` (AWS/Azure/GCP attack + hardening) |
+| ✅ Done | **Cloud Security** | ~42 files; only inside master guides | Delivered: [`Cloud/`](./Cloud/README.md) (AWS, Azure/Entra ID, GCP - attack surface + hardening) |
 | Medium | **Container & Kubernetes Security** | ~35 files; scattered | `Cloud/containers.md` or `ContainerSecurity/` |
 | Medium | **Cryptography** | ~24 files; only in cliff notes | `Documentation/cryptography.md` (primitives, TLS, hashing, PKI) |
 | Medium | **Compliance / GRC** | ~82 mentions; no structured home | `Documentation/compliance.md` (NIST CSF, ISO 27001, SOC 2 mapping) |

--- a/Cloud/README.md
+++ b/Cloud/README.md
@@ -1,0 +1,166 @@
+# ☁️ Cloud Security
+
+<div align="center">
+
+**Attack surface, assessment tooling, and hardening for AWS, Azure, and GCP**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../README.md)*
+
+![Focus](https://img.shields.io/badge/Focus-Cloud_Security-blue?style=for-the-badge)
+![Providers](https://img.shields.io/badge/Providers-AWS_%7C_Azure_%7C_GCP-orange?style=for-the-badge)
+![Use](https://img.shields.io/badge/Use-Authorized_Only-red?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Dedicated home for cloud security - the shared-responsibility model, the recurring
+misconfiguration classes, assessment tooling, and per-provider attack surface and
+hardening for AWS, Azure/Entra ID, and GCP.
+
+## ⚙️ Function
+Indexes the Cloud Security section: cross-cutting fundamentals (shared
+responsibility, IAM, CSPM, common misconfig classes, multi-cloud tooling) plus
+three provider deep-dives - each pairing the offensive perspective (enumeration,
+privilege escalation, common misconfigurations) with hardening and detection.
+
+## 🏆 Goal
+Give practitioners a single canonical cloud-security reference: understand what the
+cloud provider secures vs. what you must, how cloud environments are commonly
+assessed and attacked, and how to harden and monitor each platform.
+
+## 📋 When to Use
+- Scoping or executing an authorized cloud configuration review / penetration test
+- Looking up a provider's IAM model, common misconfigurations, or hardening baseline
+- Selecting assessment tooling (Prowler, ScoutSuite, Pacu, ROADtools)
+- Reviewing a cloud estate defensively against CIS benchmarks and the ATT&CK Cloud matrix
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#-overview)
+- [Shared Responsibility Model](#-shared-responsibility-model)
+- [Recurring Misconfiguration Classes](#-recurring-misconfiguration-classes)
+- [Assessment Tooling](#-assessment-tooling)
+- [Folder Contents](#-folder-contents)
+- [Security & Legal Disclaimer](#-security--legal-disclaimer)
+- [Resources](#-resources)
+
+---
+
+## 🎯 Overview
+
+Cloud is now the default deployment target, and cloud breaches are overwhelmingly
+caused by **customer-side misconfiguration and identity issues**, not provider
+failures. This section consolidates cloud security - previously scattered across
+the master guides - into shared fundamentals plus per-provider depth.
+
+Like [Tradecraft](../Tradecraft/) and [WebAppSecurity](../WebAppSecurity/), the
+material is **dual-use**: each provider guide pairs the offensive view (how an
+estate is enumerated and abused) with hardening and detection.
+
+---
+
+## 🔀 Shared Responsibility Model
+
+The provider secures the cloud; the customer secures what they put **in** it. The
+boundary shifts by service model:
+
+| Model | Provider secures | Customer secures |
+|-------|------------------|------------------|
+| **IaaS** (VMs) | Physical, network, hypervisor | OS, patching, apps, data, IAM, network config |
+| **PaaS** (managed services) | + OS and runtime | App config, data, IAM, access policies |
+| **SaaS** | + application | Data, user access, sharing, IAM |
+
+**In every model the customer owns identity, data, and configuration** - which is
+exactly where most cloud incidents occur.
+
+---
+
+## ⚠️ Recurring Misconfiguration Classes
+
+The same issues appear across all three providers:
+
+- **Public storage** - world-readable buckets/blobs (S3, Azure Blob, GCS).
+- **Over-permissive IAM** - wildcard permissions, unused privileged roles, no
+  least privilege; **privilege-escalation paths** through role assumption / policy
+  editing.
+- **Exposed secrets** - keys in code, environment variables, or metadata.
+- **Instance metadata abuse** - SSRF against the metadata endpoint to steal
+  instance/role credentials (mitigated by IMDSv2 on AWS).
+- **Missing logging** - CloudTrail / Azure Activity / GCP Audit Logs disabled or
+  not centralized.
+- **Weak network exposure** - management ports open to the internet, permissive
+  security groups / NSGs / firewall rules.
+- **Identity gaps** - no MFA, long-lived access keys, stale accounts.
+
+---
+
+## 🛠️ Assessment Tooling
+
+| Tool | Scope | Role |
+|------|-------|------|
+| [Prowler](https://github.com/prowler-cloud/prowler) | AWS, Azure, GCP, K8s | CIS/best-practice configuration assessment |
+| [ScoutSuite](https://github.com/nccgroup/ScoutSuite) | Multi-cloud | Configuration auditing and reporting |
+| [Pacu](https://github.com/RhinoSecurityLabs/pacu) | AWS | Offensive AWS exploitation framework |
+| [ROADtools](https://github.com/dirkjanm/ROADtools) | Azure/Entra ID | Entra ID enumeration and analysis |
+| [AzureHound](https://github.com/SpecterOps/BloodHound) | Azure/Entra ID | Attack-path mapping (BloodHound collector) |
+| [Trivy](https://github.com/aquasecurity/trivy) | Images/IaC | Vulnerability and misconfiguration scanning |
+
+Provider-native: **AWS** IAM Access Analyzer / GuardDuty / Security Hub,
+**Azure** Microsoft Defender for Cloud, **GCP** Security Command Center.
+
+---
+
+## 📂 Folder Contents
+
+| File | Description | Status |
+|------|-------------|--------|
+| **[aws.md](./aws.md)** | AWS security - IAM, S3, IMDS/SSRF credential theft, enumeration & privesc, hardening, logging | ✅ Complete |
+| **[azure.md](./azure.md)** | Azure & Entra ID - roles, consent/illicit-grant attacks, ROADtools/AzureHound, hardening | ✅ Complete |
+| **[gcp.md](./gcp.md)** | GCP - IAM, service accounts, privilege escalation, assessment, hardening | ✅ Complete |
+
+---
+
+## ⚠️ Security & Legal Disclaimer
+
+> [!CAUTION]
+> **Authorized use only.** The techniques here are for authorized cloud assessment,
+> education, and defensive research. Testing cloud accounts or tenants you do not
+> own or lack **explicit written permission** to assess is illegal - and note that
+> cloud providers also have their own **penetration-testing policies** you must
+> follow. Always work within a signed scope. See [LEGAL.md](../LEGAL.md).
+
+---
+
+## 📚 Resources
+
+- [MITRE ATT&CK Cloud Matrix](https://attack.mitre.org/matrices/enterprise/cloud/) - cloud adversary TTPs
+- [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks) - per-provider hardening baselines
+- [AWS Well-Architected - Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Microsoft Cloud Adoption Framework - Security](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/secure/)
+- [Google Cloud Security Best Practices](https://cloud.google.com/security/best-practices)
+- [Cloud Security Alliance](https://cloudsecurityalliance.org/) - vendor-neutral guidance
+
+---
+
+<div align="center">
+
+**⚠️ USE THIS REPO RESPONSIBLY AND LEGALLY ⚠️**
+
+**Repository**: [ULTIMATE CYBERSECURITY MASTER GUIDE](https://github.com/Pnwcomputers/ULTIMATE-CYBERSECURITY-MASTER-GUIDE)
+
+**Maintained by**: [Pacific Northwest Computers](https://github.com/Pnwcomputers)
+
+</div>
+
+---
+
+## Related Files
+- [aws.md](aws.md) - Amazon Web Services security
+- [azure.md](azure.md) - Microsoft Azure & Entra ID security
+- [gcp.md](gcp.md) - Google Cloud Platform security
+- [../WebAppSecurity/README.md](../WebAppSecurity/README.md) - Web app security (cloud-hosted apps)
+- [../LEGAL.md](../LEGAL.md) - Legal notice and authorized-use terms

--- a/Cloud/aws.md
+++ b/Cloud/aws.md
@@ -1,0 +1,154 @@
+# 🟧 AWS Security
+
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized assessment,
+> education, and defensive research. Test only AWS accounts you own or have
+> **explicit written permission** to assess, and follow
+> [AWS's customer support policy for penetration testing](https://aws.amazon.com/security/penetration-testing/).
+> See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+AWS security reference - the IAM model, the recurring misconfigurations, how an
+account is enumerated and escalated in an authorized test, and how to harden and
+monitor it.
+
+## ⚙️ Function
+Covers IAM (users, roles, policies, privilege escalation paths), S3 exposure,
+instance metadata (IMDS) credential theft, enumeration and assessment tooling
+(Prowler, ScoutSuite, Pacu), and the hardening/logging baseline (CloudTrail,
+GuardDuty, Security Hub, IAM Access Analyzer).
+
+## 🏆 Goal
+Let a reader assess an AWS account methodically and recommend concrete hardening
+mapped to AWS-native controls and the CIS AWS Benchmark.
+
+## 📋 When to Use
+- Authorized configuration review or penetration test of an AWS account
+- Looking up IAM privilege-escalation paths or S3/IMDS issues
+- Building an AWS hardening and monitoring baseline
+
+---
+
+## 📋 Table of Contents
+
+- [Identity & Access Management](#identity--access-management)
+- [S3 Storage Exposure](#s3-storage-exposure)
+- [Instance Metadata (IMDS) & Credential Theft](#instance-metadata-imds--credential-theft)
+- [Enumeration & Assessment](#enumeration--assessment)
+- [Privilege Escalation Paths](#privilege-escalation-paths)
+- [Hardening & Detection](#hardening--detection)
+- [Resources](#-resources)
+
+---
+
+## Identity & Access Management
+
+IAM is the heart of AWS security. Key concepts:
+
+- **Users / Groups** - long-lived identities; access keys are a common leak/risk.
+- **Roles** - assumable identities with temporary credentials (preferred over keys).
+- **Policies** - JSON permission documents; `"Action": "*"` / `"Resource": "*"` and
+  `iam:*` are red flags.
+- **STS** - issues temporary credentials via `AssumeRole`.
+
+The most common IAM problems: over-broad policies, long-lived access keys, no MFA,
+unused privileged roles, and policies that allow a principal to **escalate** (edit
+policies, create keys, or pass a privileged role).
+
+---
+
+## S3 Storage Exposure
+
+- **Public buckets/objects** - the classic breach; check bucket policy, ACLs, and
+  the account-level **Block Public Access** setting.
+- **Test (authorized):** `aws s3 ls s3://BUCKET` / `aws s3api get-bucket-policy`.
+- **Defend:** enable Block Public Access account-wide; use bucket policies over
+  ACLs (disable ACLs); enable default encryption and versioning; log access.
+
+---
+
+## Instance Metadata (IMDS) & Credential Theft
+
+An EC2 instance's role credentials are reachable at the metadata endpoint
+`169.254.169.254`. An **SSRF** in an app on the instance can steal them.
+
+- **IMDSv1** (request/response) is exploitable via simple SSRF.
+- **IMDSv2** (session/token, `PUT` then `GET`) mitigates most SSRF and should be
+  **required**.
+
+```bash
+# On an instance (authorized) - IMDSv2 flow
+TOKEN=$(curl -sX PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+curl -s -H "X-aws-ec2-metadata-token: $TOKEN" \
+  http://169.254.169.254/latest/meta-data/iam/security-credentials/
+```
+
+**Defend:** require IMDSv2 (`HttpTokens: required`), limit the hop count, and
+scope instance-role permissions tightly.
+
+---
+
+## Enumeration & Assessment
+
+```bash
+# Who am I / what can this identity do
+aws sts get-caller-identity
+aws iam list-attached-user-policies --user-name NAME
+
+# Configuration assessment (CIS / best practice)
+prowler aws                       # https://github.com/prowler-cloud/prowler
+scout aws                         # https://github.com/nccgroup/ScoutSuite
+```
+
+- **Prowler** - CIS AWS Benchmark and hundreds of checks; good for compliance evidence.
+- **ScoutSuite** - multi-cloud config audit with an HTML report.
+- **Pacu** - offensive AWS exploitation framework (enumeration, privesc modules) -
+  authorized engagements only. <https://github.com/RhinoSecurityLabs/pacu>
+
+---
+
+## Privilege Escalation Paths
+
+Rhino Security Labs catalogued ~20 IAM privesc primitives. Common ones:
+
+- `iam:CreatePolicyVersion` / `iam:SetDefaultPolicyVersion` - rewrite a policy you're attached to.
+- `iam:AttachUserPolicy` / `AttachRolePolicy` - attach `AdministratorAccess`.
+- `iam:CreateAccessKey` - mint keys for a more privileged user.
+- `iam:PassRole` + a compute service (`lambda:CreateFunction`, `ec2:RunInstances`) -
+  pass a privileged role to a resource you control.
+
+**Test:** enumerate the current principal's permissions (Pacu's `iam__privesc_scan`)
+and look for these primitives. **Defend:** deny these actions except for break-glass
+admins; use permission boundaries and SCPs.
+
+---
+
+## Hardening & Detection
+
+- **Logging:** enable **CloudTrail** (all regions, log-file validation) and centralize;
+  enable Config for resource history.
+- **Threat detection:** **GuardDuty** (anomaly/threat detection), **Security Hub**
+  (aggregated findings + CIS score).
+- **IAM:** enforce MFA, rotate/eliminate long-lived keys, least privilege, use
+  **IAM Access Analyzer** to find external/over-broad access; apply **SCPs** at the org.
+- **Data:** default encryption (KMS), Block Public Access, versioning.
+- **Network:** least-privilege security groups; no management ports to `0.0.0.0/0`.
+- Benchmark against the [CIS AWS Foundations Benchmark](https://www.cisecurity.org/benchmark/amazon_web_services).
+
+---
+
+## 📚 Resources
+
+- [AWS Penetration Testing Policy](https://aws.amazon.com/security/penetration-testing/) - what is allowed without prior approval
+- [AWS Well-Architected - Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/welcome.html)
+- [Pacu (AWS exploitation framework)](https://github.com/RhinoSecurityLabs/pacu)
+- [Prowler](https://github.com/prowler-cloud/prowler) / [ScoutSuite](https://github.com/nccgroup/ScoutSuite)
+- [MITRE ATT&CK Cloud (IaaS)](https://attack.mitre.org/matrices/enterprise/cloud/iaas/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Cloud Security section index
+- [azure.md](azure.md) - Azure & Entra ID security
+- [gcp.md](gcp.md) - Google Cloud Platform security

--- a/Cloud/azure.md
+++ b/Cloud/azure.md
@@ -1,0 +1,119 @@
+# 🟦 Azure & Entra ID Security
+
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized assessment,
+> education, and defensive research. Test only tenants/subscriptions you own or
+> have **explicit written permission** to assess, and follow the
+> [Microsoft penetration testing rules of engagement](https://www.microsoft.com/en-us/msrc/pentest-rules-of-engagement).
+> See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+Microsoft Azure and **Entra ID** (formerly Azure AD) security reference - the
+identity model, the recurring attack paths, assessment tooling, and hardening.
+
+## ⚙️ Function
+Covers the Entra ID / Azure RBAC split, common identity attacks (illicit consent
+grants, over-privileged app registrations, role abuse), enumeration tooling
+(ROADtools, AzureHound), and the hardening/detection baseline (Conditional Access,
+PIM, Defender for Cloud).
+
+## 🏆 Goal
+Let a reader assess an Azure/Entra environment and recommend concrete hardening
+mapped to Microsoft-native controls and the CIS Microsoft Azure Benchmark.
+
+## 📋 When to Use
+- Authorized review or penetration test of an Azure subscription / Entra tenant
+- Looking up Entra ID attack paths (consent, app registrations, role abuse)
+- Building an Azure/Entra hardening and monitoring baseline
+
+---
+
+## 📋 Table of Contents
+
+- [Entra ID vs Azure RBAC](#entra-id-vs-azure-rbac)
+- [Common Identity Attacks](#common-identity-attacks)
+- [Enumeration & Assessment](#enumeration--assessment)
+- [Hardening & Detection](#hardening--detection)
+- [Resources](#-resources)
+
+---
+
+## Entra ID vs Azure RBAC
+
+Azure has **two distinct permission planes** - a frequent source of confusion and
+misconfiguration:
+
+- **Entra ID (formerly Azure AD)** - the identity provider: users, groups, service
+  principals, app registrations, and **directory roles** (e.g. Global Administrator).
+- **Azure RBAC** - permissions over **resources** (subscriptions, resource groups)
+  via roles like Owner/Contributor.
+
+A principal can be powerful in one plane and not the other; **User Access
+Administrator** and **Owner** can grant themselves more, and the Entra **Global
+Administrator** can elevate to Azure RBAC via the "access management for Azure
+resources" toggle - a classic escalation bridge between the planes.
+
+---
+
+## Common Identity Attacks
+
+- **Illicit consent grant** - a malicious/over-scoped app tricks users into
+  consenting to OAuth permissions (e.g. `Mail.Read`), granting persistent access
+  without a password.
+- **Over-privileged app registrations / service principals** - apps with excessive
+  Microsoft Graph permissions or credentials that outlive their need.
+- **Directory role abuse** - standing Global Admin / Privileged Role Admin without PIM.
+- **Legacy authentication** - protocols that bypass modern MFA/Conditional Access.
+- **Device/PRT and token theft** - reuse of primary refresh tokens.
+
+---
+
+## Enumeration & Assessment
+
+```bash
+# Entra ID enumeration and analysis (authorized)
+roadrecon gather                  # https://github.com/dirkjanm/ROADtools
+
+# Configuration assessment
+prowler azure                     # https://github.com/prowler-cloud/prowler
+scout azure                       # https://github.com/nccgroup/ScoutSuite
+```
+
+- **ROADtools** (`roadrecon`) - enumerates Entra ID (users, apps, service
+  principals, roles) into an explorable database. <https://github.com/dirkjanm/ROADtools>
+- **AzureHound** - the BloodHound collector for Azure; maps attack paths across
+  Entra and Azure RBAC. <https://github.com/SpecterOps/BloodHound>
+- **Prowler / ScoutSuite** - configuration assessment against CIS/best practice.
+
+---
+
+## Hardening & Detection
+
+- **Identity:** enforce MFA; **Conditional Access** policies; block legacy auth;
+  use **Privileged Identity Management (PIM)** for just-in-time role activation.
+- **Applications:** review app consent (restrict user consent; use admin consent
+  workflow); audit service-principal credentials and Graph permissions.
+- **RBAC:** least privilege; limit Owner/User Access Administrator; separate
+  identity and resource admin duties.
+- **Monitoring:** **Microsoft Defender for Cloud** (secure score + threat
+  protection); ship Entra sign-in/audit logs and Azure Activity logs to a
+  [SIEM](../IncidentResponse/SIEM/README.md) (or Microsoft Sentinel).
+- Benchmark against the [CIS Microsoft Azure Foundations Benchmark](https://www.cisecurity.org/benchmark/azure).
+
+---
+
+## 📚 Resources
+
+- [Microsoft Penetration Testing Rules of Engagement](https://www.microsoft.com/en-us/msrc/pentest-rules-of-engagement)
+- [ROADtools (Entra ID)](https://github.com/dirkjanm/ROADtools) / [AzureHound](https://github.com/SpecterOps/BloodHound)
+- [Microsoft Cloud Adoption Framework - Secure](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/secure/)
+- [Entra ID security operations guide](https://learn.microsoft.com/en-us/entra/architecture/security-operations-introduction)
+- [MITRE ATT&CK Cloud (Azure AD / Office 365)](https://attack.mitre.org/matrices/enterprise/cloud/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Cloud Security section index
+- [aws.md](aws.md) - Amazon Web Services security
+- [gcp.md](gcp.md) - Google Cloud Platform security
+- [../Tradecraft/active-directory.md](../Tradecraft/active-directory.md) - on-prem AD (hybrid identity context)

--- a/Cloud/gcp.md
+++ b/Cloud/gcp.md
@@ -1,0 +1,128 @@
+# 🟩 GCP Security
+
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized assessment,
+> education, and defensive research. Test only GCP projects/organizations you own
+> or have **explicit written permission** to assess. Google does not require prior
+> notification for testing your own projects, but you remain bound by the
+> [Acceptable Use Policy](https://cloud.google.com/terms/aup). See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+Google Cloud Platform security reference - the IAM and service-account model, the
+recurring privilege-escalation paths, assessment tooling, and hardening.
+
+## ⚙️ Function
+Covers GCP IAM (members, roles, bindings), service accounts and impersonation,
+common privilege-escalation primitives, storage exposure, assessment tooling
+(Prowler, ScoutSuite), and the hardening/detection baseline (Security Command
+Center, Cloud Audit Logs, Organization Policy).
+
+## 🏆 Goal
+Let a reader assess a GCP project/org and recommend concrete hardening mapped to
+GCP-native controls and the CIS Google Cloud Benchmark.
+
+## 📋 When to Use
+- Authorized review or penetration test of a GCP project or organization
+- Looking up service-account impersonation / IAM privesc paths
+- Building a GCP hardening and monitoring baseline
+
+---
+
+## 📋 Table of Contents
+
+- [IAM & Service Accounts](#iam--service-accounts)
+- [Privilege Escalation Paths](#privilege-escalation-paths)
+- [Storage & Metadata Exposure](#storage--metadata-exposure)
+- [Enumeration & Assessment](#enumeration--assessment)
+- [Hardening & Detection](#hardening--detection)
+- [Resources](#-resources)
+
+---
+
+## IAM & Service Accounts
+
+GCP IAM binds **members** (users, groups, service accounts) to **roles** on a
+**resource** in a hierarchy (organization → folder → project → resource);
+permissions **inherit** downward.
+
+- **Service accounts** are both an identity *and* a resource - you can grant
+  permissions **on** a service account (e.g. impersonate it), which is the root of
+  most GCP privilege escalation.
+- **Primitive roles** (Owner/Editor/Viewer) are broad and discouraged in favor of
+  **predefined** or **custom** least-privilege roles.
+
+---
+
+## Privilege Escalation Paths
+
+Common GCP privesc primitives (catalogued by Rhino Security Labs / others):
+
+- `iam.serviceAccounts.getAccessToken` / `actAs` - impersonate a more privileged
+  service account and act as it.
+- `iam.serviceAccountKeys.create` - mint a key for a privileged service account.
+- `iam.roles.update` - edit a custom role you're bound to.
+- `cloudfunctions.functions.create` / `compute.instances.create` + `actAs` - deploy
+  a resource running as a privileged service account.
+- `setIamPolicy` on a resource - grant yourself a higher role.
+
+**Test:** enumerate the caller's permissions and look for these; the
+`GCPPrivEsc`/`gcp_scanner` style tooling helps. **Defend:** avoid `actAs`/token
+grants except where required; disable service-account key creation via org policy.
+
+---
+
+## Storage & Metadata Exposure
+
+- **Cloud Storage (GCS)** - public buckets/objects via IAM (`allUsers`/
+  `allAuthenticatedUsers`); check bucket IAM and enforce **public access prevention**.
+- **Instance metadata** - `metadata.google.internal` can yield service-account
+  tokens if reachable via SSRF; restrict metadata access and app SSRF exposure.
+
+---
+
+## Enumeration & Assessment
+
+```bash
+# Who am I / what can this identity do (authorized)
+gcloud auth list
+gcloud projects get-iam-policy PROJECT_ID
+
+# Configuration assessment
+prowler gcp                        # https://github.com/prowler-cloud/prowler
+scout gcp                          # https://github.com/nccgroup/ScoutSuite
+```
+
+- **Prowler** / **ScoutSuite** - CIS/best-practice configuration assessment.
+- The `gcloud` CLI itself is the primary enumeration tool for IAM policies,
+  service accounts, and resource inventory.
+
+---
+
+## Hardening & Detection
+
+- **IAM:** least privilege (predefined/custom roles, not primitive); avoid broad
+  `actAs`; disable service-account key creation (org policy
+  `iam.disableServiceAccountKeyCreation`); enforce MFA on user accounts.
+- **Data:** enforce **public access prevention** and uniform bucket-level access
+  on GCS; use CMEK where required.
+- **Monitoring:** **Security Command Center** (misconfiguration + threat findings);
+  ensure **Cloud Audit Logs** (Admin Activity + Data Access) are enabled and
+  centralized to a [SIEM](../IncidentResponse/SIEM/README.md).
+- **Guardrails:** **Organization Policy** constraints to enforce estate-wide rules.
+- Benchmark against the [CIS Google Cloud Platform Benchmark](https://www.cisecurity.org/benchmark/google_cloud_computing_platform).
+
+---
+
+## 📚 Resources
+
+- [Google Cloud Security Best Practices](https://cloud.google.com/security/best-practices)
+- [GCP IAM documentation](https://cloud.google.com/iam/docs)
+- [Prowler](https://github.com/prowler-cloud/prowler) / [ScoutSuite](https://github.com/nccgroup/ScoutSuite)
+- [MITRE ATT&CK Cloud (IaaS)](https://attack.mitre.org/matrices/enterprise/cloud/iaas/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Cloud Security section index
+- [aws.md](aws.md) - Amazon Web Services security
+- [azure.md](azure.md) - Microsoft Azure & Entra ID security

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 | 📊 [SIEM Deployment Guides](IncidentResponse/SIEM/) | ELK Stack, Wazuh, Splunk, and Graylog setup and configuration |
 | 🔍 [OSINT Guide, Tools & Techniques](OSINT/OSINT_GUIDE.md) | Comprehensive OSINT methodology - 400+ categorized tools, investigation workflows, automated VM setup |
 | 🕸️ [Web Application Security](WebAppSecurity/) | OWASP Top 10 deep-dive and a full web app pentest methodology (recon, Burp workflow, injection/access-control/API testing) |
+| ☁️ [Cloud Security](Cloud/) | Shared-responsibility model, common misconfigurations, and per-provider attack surface & hardening for AWS, Azure/Entra ID, and GCP |
 | 🔴 [OPSEC](OPSEC/) | Operational security practices - anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 [Homelab Guides](Homelab/) | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🤖 [AI Cybersecurity Resources](AI/README.md) | Self-hosted AI agents (OpenClaw, AnythingLLM), LLM prompting for security, offline AI deployment, AI-powered security workflows |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -26,6 +26,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 - **OSINT Investigator?** → [OSINT Guide](OSINT/OSINT_GUIDE.md) + [Tradecraft/OSINT Threat Intel](Tradecraft/osint-threat-intel.md)
 - **Red Team Operator?** → [Tradecraft](Tradecraft/) + [Advanced Techniques](advanced_techniques_supplement.md) + [Scripts](Scripts/)
 - **Web App Pentester?** → [Web Application Security](WebAppSecurity/) ([OWASP Top 10](WebAppSecurity/owasp-top-10.md) + [Methodology](WebAppSecurity/methodology.md))
+- **Cloud Security?** → [Cloud Security](Cloud/) ([AWS](Cloud/aws.md) · [Azure/Entra ID](Cloud/azure.md) · [GCP](Cloud/gcp.md))
 - **Hardware Hacker?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts II–III) + [Enhanced Master Guide](ENHANCED_MASTER_GUIDE.md) + [Firmware & Hardware Compatibility](firmware-hardware-compatibility.md)
 - **AI / LLM Security?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Part I) + [AI Resources](AI/README.md)
 - **SDR / RF / Space?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts V–VI) + [SDR](SDR/) + [SpaceSecurity](SpaceSecurity/)
@@ -89,6 +90,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 | 🔍 **[OSINT Guide, Tools & Techniques](OSINT/OSINT_GUIDE.md)** | Comprehensive OSINT methodology; 400+ categorized tools, investigation workflows |
 | 🕵️ **[Tradecraft](Tradecraft/)** | Offensive tradecraft; AD attacks, C2 frameworks, AV/EDR evasion, LOLBins, network detection evasion, threat intel |
 | 🕸️ **[Web Application Security](WebAppSecurity/)** | OWASP Top 10 deep-dive and web app pentest methodology (Burp workflow, injection/access-control/API testing) |
+| ☁️ **[Cloud Security](Cloud/)** | AWS, Azure/Entra ID, and GCP - shared responsibility, misconfigurations, attack surface, and hardening |
 | 🔴 **[OPSEC](OPSEC/)** | Operational security; anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 **[Homelab Guides](Homelab/)** | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🚨 **[Incident Response](IncidentResponse/)** | Blue Team operations; threat detection, log aggregation, artifact analysis, SIEM setup |

--- a/ultimate_cybersecurity_master_guide.md
+++ b/ultimate_cybersecurity_master_guide.md
@@ -976,6 +976,11 @@ net group /domain
 
 ## Cloud Security & Exploitation
 
+> [!NOTE]
+> **Canonical reference:** the dedicated [Cloud/](Cloud/README.md) section covers
+> AWS, Azure/Entra ID, and GCP in depth (misconfigurations, attack surface,
+> hardening). This section is a summary.
+
 ### AWS Enumeration
 ```bash
 # List S3 buckets


### PR DESCRIPTION
Second coverage-gap section from the audit's Content Expansion Plan (~42 files referenced cloud; it lived only inside the master guides). New `Cloud/` section, house style.

## New content

| File | Covers |
|------|--------|
| `README.md` | Shared-responsibility model, recurring misconfiguration classes, multi-cloud assessment tooling |
| `aws.md` | IAM, S3 exposure, **IMDS/SSRF credential theft**, enumeration & **privilege-escalation paths**, hardening (CloudTrail, GuardDuty, Security Hub) |
| `azure.md` | **Entra ID vs Azure RBAC**, consent/role attacks, ROADtools/AzureHound, Conditional Access/PIM/Defender hardening |
| `gcp.md` | IAM & **service-account impersonation**, privesc primitives, SCC/audit-log hardening |

## Accuracy

- Tool repos **verified active** (Pacu, ScoutSuite, Prowler, ROADtools, AzureHound, Trivy)
- Each provider guide links that provider's **own penetration-testing policy** (AWS/Microsoft/Google) — important, since cloud testing is governed by provider rules, not just the customer's scope
- Uses **Entra ID** (not "Azure AD"), consistent with the repo's earlier rename

## Wiring & consistency

- Listed in `README.md` + `START_HERE.md`; added a **"Cloud Security?"** role path
- Canonical cross-link from the master guide's cloud section
- F-09 authorization header on every doc; dual-use structure

## Verification

- **All 95 links verified live online** — 0 errors
- Anchors resolve; markdownlint clean; `AUDIT_REPORT.md` G marked done

Next up per your request: **Compliance / GRC**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)