### PR TITLE
feat: add Compliance & GRC section (deliverable G gap)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -185,7 +185,7 @@ listed topic is **referenced in many files but lacks a dedicated section**.
 | ✅ Done | **Cloud Security** | ~42 files; only inside master guides | Delivered: [`Cloud/`](./Cloud/README.md) (AWS, Azure/Entra ID, GCP - attack surface + hardening) |
 | Medium | **Container & Kubernetes Security** | ~35 files; scattered | `Cloud/containers.md` or `ContainerSecurity/` |
 | Medium | **Cryptography** | ~24 files; only in cliff notes | `Documentation/cryptography.md` (primitives, TLS, hashing, PKI) |
-| Medium | **Compliance / GRC** | ~82 mentions; no structured home | `Documentation/compliance.md` (NIST CSF, ISO 27001, SOC 2 mapping) |
+| ✅ Done | **Compliance / GRC** | ~82 mentions; no structured home | Delivered: [`Compliance/`](./Compliance/README.md) (NIST CSF 2.0, ISO 27001:2022, SOC 2, PCI DSS 4.0.1, CIS v8; GDPR/HIPAA/CCPA) |
 | Low | **Detection Engineering** | ~27 files; partial via SIEM | extend `IncidentResponse/` (Sigma/YARA rule authoring) |
 
 Each new section should follow the house template (Purpose/Function/Goal/When to

--- a/Compliance/README.md
+++ b/Compliance/README.md
@@ -1,0 +1,160 @@
+# 📋 Compliance & GRC
+
+<div align="center">
+
+**Governance, Risk, and Compliance - frameworks, regulations, and control mapping**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../README.md)*
+
+![Focus](https://img.shields.io/badge/Focus-GRC-blue?style=for-the-badge)
+![Frameworks](https://img.shields.io/badge/Frameworks-NIST_%7C_ISO_%7C_SOC_2-orange?style=for-the-badge)
+![Type](https://img.shields.io/badge/Type-Governance-green?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Dedicated home for Governance, Risk, and Compliance - the major security control
+frameworks, the data-protection regulations, and a practical approach to mapping
+one set of controls to many requirements.
+
+## ⚙️ Function
+Indexes the Compliance & GRC section: GRC fundamentals and a control-mapping
+approach (this file), the major control frameworks (NIST CSF 2.0, ISO/IEC
+27001:2022, SOC 2, PCI DSS 4.0.1, CIS Controls v8, NIST 800-53/800-171), and the
+key data-protection regulations (GDPR, HIPAA, CCPA/CPRA).
+
+## 🏆 Goal
+Give practitioners a single reference for which framework applies when, how the
+frameworks relate, and how to implement controls once and satisfy multiple
+requirements - tying governance back to the technical controls elsewhere in this
+repo.
+
+## 📋 When to Use
+- Choosing a framework for an organization or a customer requirement
+- Preparing for an audit or certification (SOC 2, ISO 27001, PCI DSS)
+- Mapping existing technical controls to compliance requirements
+- Understanding a data-protection obligation (GDPR/HIPAA/CCPA)
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#-overview)
+- [What GRC Is](#-what-grc-is)
+- [Choosing a Framework](#-choosing-a-framework)
+- [Control Mapping (Do It Once, Satisfy Many)](#-control-mapping-do-it-once-satisfy-many)
+- [Folder Contents](#-folder-contents)
+- [Important Notice](#-important-notice)
+- [Resources](#-resources)
+
+---
+
+## 🎯 Overview
+
+Compliance is heavily referenced across this repository but previously had no home.
+This section consolidates it. The theme throughout: **compliance is the evidence
+that good security controls exist and operate** - the technical work lives in the
+[IncidentResponse](../IncidentResponse/), [Cloud](../Cloud/),
+[WebAppSecurity](../WebAppSecurity/), and [Checklists](../Checklists/) sections;
+GRC organizes, requires, and demonstrates it.
+
+---
+
+## 🏛️ What GRC Is
+
+- **Governance** - the policies, roles, and accountability that direct a security
+  program (leadership ownership, risk appetite, standards).
+- **Risk** - identifying, assessing, and treating risk (accept / mitigate /
+  transfer / avoid), usually via a risk register and periodic assessment.
+- **Compliance** - demonstrating adherence to chosen frameworks and applicable
+  laws/regulations, with evidence.
+
+A framework provides the **control set**; risk management decides **which controls
+matter most**; governance ensures they are **owned and maintained**.
+
+---
+
+## 🧭 Choosing a Framework
+
+| If you need to… | Consider |
+|-----------------|----------|
+| A flexible, risk-based program (US-centric, widely recognized) | **NIST CSF 2.0** |
+| An internationally recognized certification | **ISO/IEC 27001:2022** |
+| Assure customers/partners of your controls (SaaS/service orgs) | **SOC 2** |
+| Handle payment card data | **PCI DSS 4.0.1** (mandatory) |
+| A prioritized, prescriptive starting set of controls | **CIS Controls v8** |
+| A US federal / government-adjacent baseline | **NIST SP 800-53 / 800-171** |
+
+Details in [frameworks.md](./frameworks.md). Regulatory obligations (GDPR, HIPAA,
+CCPA) are **not optional** and apply based on data and jurisdiction - see
+[regulations.md](./regulations.md).
+
+---
+
+## 🔗 Control Mapping (Do It Once, Satisfy Many)
+
+The frameworks overlap heavily. Rather than implement each in isolation:
+
+1. **Pick a primary framework** (often NIST CSF 2.0 or ISO 27001) as the backbone.
+2. **Implement the underlying technical controls** (MFA, logging, encryption,
+   access control, patching) - the substance lives in this repo's technical sections.
+3. **Map** those controls to each framework/regulation you must satisfy, so one
+   control (e.g. centralized logging) provides evidence for CSF *Detect*, ISO
+   *A.8.15/A.8.16*, SOC 2 *CC7*, and PCI *Req. 10* at once.
+4. **Collect evidence** continuously (config, logs, tickets) rather than scrambling
+   at audit time.
+
+The [Secure Controls Framework (SCF)](https://securecontrolsframework.com/) and
+NIST's [OLIR mappings](https://csrc.nist.gov/projects/olir) publish
+cross-framework crosswalks to accelerate this.
+
+---
+
+## 📂 Folder Contents
+
+| File | Description | Status |
+|------|-------------|--------|
+| **[frameworks.md](./frameworks.md)** | Control frameworks - NIST CSF 2.0, ISO 27001:2022, SOC 2, PCI DSS 4.0.1, CIS Controls v8, NIST 800-53/800-171 | ✅ Complete |
+| **[regulations.md](./regulations.md)** | Data-protection regulations - GDPR, HIPAA, CCPA/CPRA, and breach-notification duties | ✅ Complete |
+
+---
+
+## ⚠️ Important Notice
+
+> [!IMPORTANT]
+> **This is educational reference material, not legal or compliance advice.**
+> Framework versions, regulatory thresholds, and applicability change and depend on
+> your jurisdiction, industry, and data. Verify against the authoritative source
+> and consult qualified legal/compliance counsel and, where required, a qualified
+> assessor (e.g. a PCI QSA or ISO certification body) before relying on it.
+
+---
+
+## 📚 Resources
+
+- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
+- [ISO/IEC 27001](https://www.iso.org/standard/27001)
+- [AICPA SOC 2](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2)
+- [PCI Security Standards Council](https://www.pcisecuritystandards.org/)
+- [CIS Controls](https://www.cisecurity.org/controls)
+- [Secure Controls Framework (crosswalks)](https://securecontrolsframework.com/)
+
+---
+
+<div align="center">
+
+**Repository**: [ULTIMATE CYBERSECURITY MASTER GUIDE](https://github.com/Pnwcomputers/ULTIMATE-CYBERSECURITY-MASTER-GUIDE)
+
+**Maintained by**: [Pacific Northwest Computers](https://github.com/Pnwcomputers)
+
+</div>
+
+---
+
+## Related Files
+- [frameworks.md](frameworks.md) - Security control frameworks
+- [regulations.md](regulations.md) - Data-protection regulations
+- [../IncidentResponse/README.md](../IncidentResponse/README.md) - the detection/response controls compliance requires
+- [../Checklists/README.md](../Checklists/README.md) - operational checklists that implement controls

--- a/Compliance/frameworks.md
+++ b/Compliance/frameworks.md
@@ -1,0 +1,160 @@
+# 🏛️ Security Control Frameworks
+
+> [!IMPORTANT]
+> Educational reference, **not** compliance advice. Framework versions change -
+> verify against the authoritative source and engage a qualified assessor before
+> relying on this for an audit or certification. See the
+> [section notice](README.md#-important-notice).
+
+## 🎯 Purpose
+A working reference to the major security control frameworks - what each is, when
+it applies, how it is structured, and how they relate.
+
+## ⚙️ Function
+Covers NIST CSF 2.0, ISO/IEC 27001:2022, SOC 2, PCI DSS 4.0.1, CIS Controls v8,
+and the NIST SP 800-53 / 800-171 baselines, with version notes verified against
+each authoritative source.
+
+## 🏆 Goal
+Let a reader pick the right framework, understand its structure, and see how a
+single set of technical controls maps across several of them.
+
+## 📋 When to Use
+- Selecting or comparing frameworks
+- Preparing for a certification/audit
+- Mapping technical controls to a framework's requirements
+
+---
+
+## 📋 Table of Contents
+
+- [NIST Cybersecurity Framework (CSF) 2.0](#nist-cybersecurity-framework-csf-20)
+- [ISO/IEC 27001:2022](#isoiec-270012022)
+- [SOC 2](#soc-2)
+- [PCI DSS 4.0.1](#pci-dss-401)
+- [CIS Controls v8](#cis-controls-v8)
+- [NIST SP 800-53 & 800-171](#nist-sp-800-53--800-171)
+- [How They Relate](#how-they-relate)
+- [Resources](#-resources)
+
+---
+
+## NIST Cybersecurity Framework (CSF) 2.0
+
+Released **2024**; the widely used, voluntary, risk-based framework. CSF 2.0's
+headline change is a new **Govern** function, making **six** core functions:
+
+1. **Govern (GV)** *(new in 2.0)* - organizational context, risk strategy, roles, policy, oversight
+2. **Identify (ID)** - assets, risks, and the environment
+3. **Protect (PR)** - safeguards (access control, awareness, data security)
+4. **Detect (DE)** - find events (monitoring, detection processes)
+5. **Respond (RS)** - act on incidents
+6. **Recover (RC)** - restore capabilities
+
+- **Use it for:** a flexible program backbone; maps well to other frameworks.
+- **Not a certification** - it is a framework you self-adopt/assess against.
+
+---
+
+## ISO/IEC 27001:2022
+
+The leading **international, certifiable** standard for an Information Security
+Management System (ISMS). The **2022** revision supersedes 2013.
+
+- **ISMS-centric:** requires risk assessment, a Statement of Applicability, and
+  continual improvement - not just controls.
+- **Annex A (2022):** **93 controls** organized into **4 themes** - Organizational,
+  People, Physical, Technological (down from 114 controls / 14 domains in 2013).
+- **Use it for:** an internationally recognized certification via an accredited body.
+
+---
+
+## SOC 2
+
+An **attestation report** (not a certification) under the AICPA's **Trust Services
+Criteria** - common for SaaS/service organizations to assure customers.
+
+- **Five Trust Services Criteria:** **Security** (the required "common criteria"),
+  plus optional **Availability, Processing Integrity, Confidentiality, Privacy**.
+- **Type I** - controls designed appropriately at a point in time; **Type II** -
+  controls operated effectively over a period (usually 3-12 months).
+- **Use it for:** demonstrating control effectiveness to customers/partners.
+
+---
+
+## PCI DSS 4.0.1
+
+**Mandatory** for organizations that store, process, or transmit payment card data.
+**v4.0.1** (2024) is the current version; **v3.2.1 was retired in 2024**.
+
+- **12 requirements** across 6 goals (network security, data protection, vulnerability
+  management, access control, monitoring, and policy).
+- v4.x adds a **customized approach** option, more MFA, and stronger authentication
+  requirements; some future-dated requirements phased in over time.
+- **Use it for:** payment-card environments - compliance is contractually required.
+  Validation scales from a Self-Assessment Questionnaire (SAQ) to a QSA audit.
+
+---
+
+## CIS Controls v8
+
+A **prioritized, prescriptive** set of **18 controls** (v8 consolidated the prior
+20), each broken into safeguards and grouped into **Implementation Groups (IG1-IG3)**
+by organizational maturity/resources.
+
+- **IG1** is the "essential cyber hygiene" baseline every org should meet.
+- **Use it for:** a concrete, actionable starting point; maps to CSF, ISO, and others.
+- Pairs with the **CIS Benchmarks** (per-technology hardening) referenced in the
+  [Cloud](../Cloud/README.md) and endpoint guides.
+
+---
+
+## NIST SP 800-53 & 800-171
+
+- **SP 800-53 (Rev 5)** - the comprehensive control catalog for **US federal**
+  systems (and the basis for FedRAMP); organized into control families.
+- **SP 800-171 (Rev 3)** - protecting **Controlled Unclassified Information (CUI)**
+  in non-federal systems; the basis for **CMMC** in the US defense supply chain.
+- **Use them for:** US government systems, federal contracting, and the defense
+  industrial base.
+
+---
+
+## How They Relate
+
+They overlap far more than they differ - all require access control, logging,
+encryption, vulnerability management, and incident response. Practical guidance:
+
+- Choose **one backbone** (commonly NIST CSF 2.0 or ISO 27001).
+- Implement the **technical controls once** (see this repo's technical sections).
+- **Map** them to every framework you must satisfy (see
+  [Control Mapping](README.md#-control-mapping-do-it-once-satisfy-many)).
+
+| Control area | CSF 2.0 | ISO 27001:2022 | SOC 2 | PCI DSS 4.0.1 |
+|--------------|---------|-----------------|-------|----------------|
+| Access control / MFA | PR.AA | A.5.15-.18, A.8.2-.5 | CC6 | Req. 7, 8 |
+| Logging & monitoring | DE.CM | A.8.15, A.8.16 | CC7 | Req. 10 |
+| Encryption | PR.DS | A.8.24 | CC6 | Req. 3, 4 |
+| Vulnerability mgmt | ID.RA / PR.PS | A.8.8 | CC7 | Req. 6, 11 |
+| Incident response | RS / RC | A.5.24-.28 | CC7 | Req. 12.10 |
+
+*Mappings are indicative; use an authoritative crosswalk (NIST OLIR, SCF) for audit work.*
+
+---
+
+## 📚 Resources
+
+- [NIST CSF 2.0 (final)](https://csrc.nist.gov/pubs/cswp/29/the-nist-cybersecurity-framework-csf-20/final)
+- [ISO/IEC 27001](https://www.iso.org/standard/27001)
+- [AICPA SOC 2 / Trust Services Criteria](https://www.aicpa-cima.com/topic/audit-assurance/audit-and-assurance-greater-than-soc-2)
+- [PCI DSS Document Library](https://www.pcisecuritystandards.org/document_library/)
+- [CIS Controls](https://www.cisecurity.org/controls)
+- [NIST SP 800-53 Rev 5](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final) / [SP 800-171](https://csrc.nist.gov/pubs/sp/800/171/r3/final)
+- [NIST OLIR crosswalks](https://csrc.nist.gov/projects/olir)
+
+---
+
+## Related Files
+- [README.md](README.md) - Compliance & GRC section index
+- [regulations.md](regulations.md) - data-protection regulations
+- [../IncidentResponse/SIEM/README.md](../IncidentResponse/SIEM/README.md) - logging/monitoring controls (CSF Detect, PCI Req. 10)

--- a/Compliance/regulations.md
+++ b/Compliance/regulations.md
@@ -1,0 +1,136 @@
+# ⚖️ Data-Protection Regulations
+
+> [!IMPORTANT]
+> Educational reference, **not** legal advice. Regulatory thresholds, definitions,
+> and penalties change and depend on jurisdiction, industry, and the data involved.
+> Consult qualified legal counsel for your specific situation. See the
+> [section notice](README.md#-important-notice).
+
+## 🎯 Purpose
+A practitioner's orientation to the major data-protection regulations - who they
+apply to, what they require, and their breach-notification duties.
+
+## ⚙️ Function
+Covers GDPR (EU/EEA), HIPAA (US healthcare), and CCPA/CPRA (California), plus the
+common thread of breach notification, at the level a security practitioner needs
+to know when they apply and what controls they drive.
+
+## 🏆 Goal
+Let a reader recognize which regulation applies to a given system or dataset and
+what security obligations follow - then route to counsel for specifics.
+
+## 📋 When to Use
+- Determining whether a regulation applies to a system or dataset
+- Understanding the security controls a regulation implies
+- Preparing breach-notification readiness
+
+---
+
+## 📋 Table of Contents
+
+- [GDPR (EU/EEA)](#gdpr-eueea)
+- [HIPAA (US Healthcare)](#hipaa-us-healthcare)
+- [CCPA / CPRA (California)](#ccpa--cpra-california)
+- [Breach Notification (Common Thread)](#breach-notification-common-thread)
+- [What This Means for Security](#what-this-means-for-security)
+- [Resources](#-resources)
+
+---
+
+## GDPR (EU/EEA)
+
+The EU **General Data Protection Regulation** - the most influential privacy law
+globally.
+
+- **Applies to:** any organization processing the personal data of people in the
+  EU/EEA, **regardless of where the organization is** (extraterritorial).
+- **Key principles:** lawfulness, purpose limitation, data minimization, accuracy,
+  storage limitation, integrity/confidentiality, and accountability.
+- **Data-subject rights:** access, rectification, erasure ("right to be forgotten"),
+  portability, and objection.
+- **Security duty:** "appropriate technical and organizational measures" (Art. 32) -
+  encryption, resilience, testing.
+- **Penalties:** up to **€20 million or 4% of global annual turnover**, whichever
+  is higher.
+
+---
+
+## HIPAA (US Healthcare)
+
+The US **Health Insurance Portability and Accountability Act** - protects health
+information.
+
+- **Applies to:** **covered entities** (providers, health plans, clearinghouses)
+  and their **business associates** handling Protected Health Information (PHI).
+- **Security Rule:** requires administrative, physical, and technical safeguards for
+  electronic PHI (access control, audit controls, integrity, transmission security).
+- **Privacy Rule:** governs use and disclosure of PHI.
+- **Breach Notification Rule:** notify affected individuals, HHS, and (for large
+  breaches) the media.
+- **Penalties:** tiered civil penalties per violation, up to substantial annual caps.
+
+---
+
+## CCPA / CPRA (California)
+
+The **California Consumer Privacy Act**, amended and strengthened by the **California
+Privacy Rights Act (CPRA)**.
+
+- **Applies to:** for-profit businesses handling California residents' personal
+  information that meet thresholds (revenue, volume of data, or data-selling share).
+- **Consumer rights:** know, delete, correct, opt out of sale/sharing, and limit
+  use of sensitive personal information.
+- **CPRA additions:** a dedicated enforcement agency (CPPA), a "sensitive personal
+  information" category, and data-minimization/retention duties.
+- **Note:** many other US states have since enacted comparable laws - check the
+  specific state(s) where your users reside.
+
+---
+
+## Breach Notification (Common Thread)
+
+Nearly every regime requires timely notification after a personal-data breach:
+
+- **GDPR:** notify the supervisory authority **within 72 hours** of becoming aware
+  (where feasible); notify individuals if high risk.
+- **HIPAA:** notify without unreasonable delay, and **no later than 60 days**;
+  large breaches also require HHS/media notice.
+- **US state laws:** timelines and thresholds vary by state.
+
+This makes **detection and logging** (see [IncidentResponse](../IncidentResponse/README.md))
+a compliance requirement, not just good practice - you cannot notify about what you
+cannot detect, and the clock starts when you become aware.
+
+---
+
+## What This Means for Security
+
+Regulations rarely prescribe specific technology, but consistently drive the same
+controls:
+
+- **Data inventory & classification** - you must know what personal data you hold.
+- **Access control & MFA** - limit who can reach regulated data.
+- **Encryption** - in transit and at rest (often a safe-harbor factor for breaches).
+- **Logging & monitoring** - to detect and evidence incidents within notification windows.
+- **Incident response** - a tested plan that meets the notification clocks.
+- **Data minimization & retention** - collect and keep less.
+
+Implement these once (see the technical sections of this repo) and map them to each
+applicable regulation and framework - see
+[Control Mapping](README.md#-control-mapping-do-it-once-satisfy-many).
+
+---
+
+## 📚 Resources
+
+- [GDPR - official text (EUR-Lex)](https://eur-lex.europa.eu/eli/reg/2016/679/oj)
+- [HHS HIPAA for Professionals](https://www.hhs.gov/hipaa/for-professionals/index.html)
+- [California CCPA (OAG)](https://oag.ca.gov/privacy/ccpa)
+- [California Privacy Protection Agency (CPPA)](https://cppa.ca.gov/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Compliance & GRC section index
+- [frameworks.md](frameworks.md) - security control frameworks
+- [../IncidentResponse/README.md](../IncidentResponse/README.md) - detection & response that breach-notification duties require

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 | 🔍 [OSINT Guide, Tools & Techniques](OSINT/OSINT_GUIDE.md) | Comprehensive OSINT methodology - 400+ categorized tools, investigation workflows, automated VM setup |
 | 🕸️ [Web Application Security](WebAppSecurity/) | OWASP Top 10 deep-dive and a full web app pentest methodology (recon, Burp workflow, injection/access-control/API testing) |
 | ☁️ [Cloud Security](Cloud/) | Shared-responsibility model, common misconfigurations, and per-provider attack surface & hardening for AWS, Azure/Entra ID, and GCP |
+| 📋 [Compliance & GRC](Compliance/) | Governance, risk & compliance - NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS Controls, and GDPR/HIPAA/CCPA with control mapping |
 | 🔴 [OPSEC](OPSEC/) | Operational security practices - anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 [Homelab Guides](Homelab/) | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🤖 [AI Cybersecurity Resources](AI/README.md) | Self-hosted AI agents (OpenClaw, AnythingLLM), LLM prompting for security, offline AI deployment, AI-powered security workflows |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -27,6 +27,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 - **Red Team Operator?** → [Tradecraft](Tradecraft/) + [Advanced Techniques](advanced_techniques_supplement.md) + [Scripts](Scripts/)
 - **Web App Pentester?** → [Web Application Security](WebAppSecurity/) ([OWASP Top 10](WebAppSecurity/owasp-top-10.md) + [Methodology](WebAppSecurity/methodology.md))
 - **Cloud Security?** → [Cloud Security](Cloud/) ([AWS](Cloud/aws.md) · [Azure/Entra ID](Cloud/azure.md) · [GCP](Cloud/gcp.md))
+- **Compliance / Auditor?** → [Compliance & GRC](Compliance/) ([Frameworks](Compliance/frameworks.md) · [Regulations](Compliance/regulations.md))
 - **Hardware Hacker?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts II–III) + [Enhanced Master Guide](ENHANCED_MASTER_GUIDE.md) + [Firmware & Hardware Compatibility](firmware-hardware-compatibility.md)
 - **AI / LLM Security?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Part I) + [AI Resources](AI/README.md)
 - **SDR / RF / Space?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts V–VI) + [SDR](SDR/) + [SpaceSecurity](SpaceSecurity/)
@@ -91,6 +92,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 | 🕵️ **[Tradecraft](Tradecraft/)** | Offensive tradecraft; AD attacks, C2 frameworks, AV/EDR evasion, LOLBins, network detection evasion, threat intel |
 | 🕸️ **[Web Application Security](WebAppSecurity/)** | OWASP Top 10 deep-dive and web app pentest methodology (Burp workflow, injection/access-control/API testing) |
 | ☁️ **[Cloud Security](Cloud/)** | AWS, Azure/Entra ID, and GCP - shared responsibility, misconfigurations, attack surface, and hardening |
+| 📋 **[Compliance & GRC](Compliance/)** | Frameworks (NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS) and regulations (GDPR, HIPAA, CCPA) with control mapping |
 | 🔴 **[OPSEC](OPSEC/)** | Operational security; anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 **[Homelab Guides](Homelab/)** | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🚨 **[Incident Response](IncidentResponse/)** | Blue Team operations; threat detection, log aggregation, artifact analysis, SIEM setup |


### PR DESCRIPTION
Coverage-gap section from the audit's Content Expansion Plan (~82 files referenced compliance; no structured home). New `Compliance/` section, house style.

## New content

| File | Covers |
|------|--------|
| `README.md` | GRC fundamentals, a **framework-selection guide**, and a **control-mapping** approach (implement once, satisfy many) |
| `frameworks.md` | **NIST CSF 2.0** (six functions incl. new *Govern*), **ISO/IEC 27001:2022** (93 controls / 4 themes), **SOC 2** (Trust Services Criteria, Type I/II), **PCI DSS 4.0.1**, **CIS Controls v8**, NIST SP 800-53/800-171 — plus a cross-framework control-mapping table |
| `regulations.md` | **GDPR**, **HIPAA**, **CCPA/CPRA**, and breach-notification duties |

## Accuracy

Every version **verified against the authoritative source**: NIST CSF 2.0 (final, 2024), **PCI DSS v4.0.1 current / v3.2.1 retired**, ISO/IEC 27001:2022, CIS Controls v8, AICPA SOC 2. The framework/regulation facts (CSF's new Govern function, ISO's 93-control restructure, GDPR's 72-hour / HIPAA's 60-day notification clocks) are stated precisely.

## Appropriate framing

This is **governance content, not offensive** — so instead of the F-09 authorization header, each doc carries a prominent **"educational reference, not legal/compliance advice"** notice directing readers to qualified counsel/assessors. The section repeatedly ties compliance back to the repo's technical controls (IncidentResponse, Cloud, WebAppSec, Checklists).

## Wiring

- Listed in `README.md` + `START_HERE.md`; added a **"Compliance / Auditor?"** role path
- `AUDIT_REPORT.md` G marked done

## Verification

- **All 71 links verified live** (incl. NIST, PCI SSC, AICPA, EUR-Lex, HHS, California OAG/CPPA) — 0 errors
- Anchors resolve; markdownlint clean

With this, the two you asked for — **Cloud** (#58, merged) and **Compliance/GRC** — are both delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)