### PR TITLE
feat: add Container & Kubernetes Security section (deliverable G gap)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -183,7 +183,7 @@ listed topic is **referenced in many files but lacks a dedicated section**.
 |----------|-------|----------|---------------|
 | ✅ Done | **Web Application Security** | ~47 files mentioned it; no dedicated section | Delivered: [`WebAppSecurity/`](./WebAppSecurity/README.md) (OWASP Top 10:2025 deep-dive + full methodology) |
 | ✅ Done | **Cloud Security** | ~42 files; only inside master guides | Delivered: [`Cloud/`](./Cloud/README.md) (AWS, Azure/Entra ID, GCP - attack surface + hardening) |
-| Medium | **Container & Kubernetes Security** | ~35 files; scattered | `Cloud/containers.md` or `ContainerSecurity/` |
+| ✅ Done | **Container & Kubernetes Security** | ~35 files; scattered | Delivered: [`ContainerSecurity/`](./ContainerSecurity/README.md) (image/runtime, escape, K8s RBAC/Pod Security) |
 | Medium | **Cryptography** | ~24 files; only in cliff notes | `Documentation/cryptography.md` (primitives, TLS, hashing, PKI) |
 | ✅ Done | **Compliance / GRC** | ~82 mentions; no structured home | Delivered: [`Compliance/`](./Compliance/README.md) (NIST CSF 2.0, ISO 27001:2022, SOC 2, PCI DSS 4.0.1, CIS v8; GDPR/HIPAA/CCPA) |
 | Low | **Detection Engineering** | ~27 files; partial via SIEM | extend `IncidentResponse/` (Sigma/YARA rule authoring) |

--- a/ContainerSecurity/README.md
+++ b/ContainerSecurity/README.md
@@ -1,0 +1,141 @@
+# 📦 Container & Kubernetes Security
+
+<div align="center">
+
+**Threat model, attack surface, and hardening for containers and Kubernetes**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../README.md)*
+
+![Focus](https://img.shields.io/badge/Focus-Container_Security-blue?style=for-the-badge)
+![Kubernetes](https://img.shields.io/badge/Orchestration-Kubernetes-orange?style=for-the-badge)
+![Use](https://img.shields.io/badge/Use-Authorized_Only-red?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Dedicated home for container and Kubernetes security - the image/runtime attack
+surface, container escape, the Kubernetes threat model, and hardening for both.
+
+## ⚙️ Function
+Indexes the Container Security section: cross-cutting fundamentals and tooling
+(this file), container/image security and escape techniques
+([containers.md](./containers.md)), and Kubernetes security - RBAC, Pod Security
+Standards, secrets, network policy, attack paths, and hardening
+([kubernetes.md](./kubernetes.md)) - each pairing offense with defense.
+
+## 🏆 Goal
+Give practitioners a single reference for how containerized and orchestrated
+workloads are attacked and how to harden them, complementing the
+[Cloud](../Cloud/README.md) section.
+
+## 📋 When to Use
+- Assessing or hardening a container image, runtime, or Kubernetes cluster
+- Looking up container-escape vectors or Kubernetes attack paths
+- Selecting scanning/runtime-security tooling
+- Reviewing a cluster against the CIS Kubernetes Benchmark
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#-overview)
+- [The Container Threat Model](#-the-container-threat-model)
+- [Tooling](#-tooling)
+- [Folder Contents](#-folder-contents)
+- [Security & Legal Disclaimer](#-security--legal-disclaimer)
+- [Resources](#-resources)
+
+---
+
+## 🎯 Overview
+
+Containers and Kubernetes are now the default way applications ship and run, and
+they add attack surface at several layers - the image, the container runtime, the
+host, and the orchestrator. This section consolidates container security
+(previously scattered across the master guides) into fundamentals plus depth on
+containers and Kubernetes.
+
+Like [Cloud](../Cloud/) and [Tradecraft](../Tradecraft/), the material is
+**dual-use**: each guide pairs the offensive view (how workloads are attacked and
+escaped) with hardening and detection.
+
+---
+
+## 🎯 The Container Threat Model
+
+Attack surface spans four layers:
+
+| Layer | Example risks |
+|-------|---------------|
+| **Image** | Vulnerable packages, embedded secrets, untrusted base images, no signing |
+| **Runtime** | Privileged containers, over-broad capabilities, mounted `docker.sock`, `hostPath` |
+| **Host** | Container **escape** to the node; shared kernel; weak isolation |
+| **Orchestrator (K8s)** | Over-permissive RBAC, exposed API server, weak Pod Security, flat networking |
+
+The defining property: **containers share the host kernel**, so isolation is
+weaker than a VM - a misconfiguration or kernel vulnerability can lead to escape.
+
+---
+
+## 🛠️ Tooling
+
+| Tool | Role |
+|------|------|
+| [Trivy](https://github.com/aquasecurity/trivy) | Image, filesystem, and IaC vulnerability + misconfiguration scanning |
+| [kube-bench](https://github.com/aquasecurity/kube-bench) | CIS Kubernetes Benchmark checks |
+| [kubescape](https://github.com/kubescape/kubescape) | Cluster risk analysis, misconfiguration, and compliance scanning |
+| [Falco](https://github.com/falcosecurity/falco) | Runtime threat detection (syscall-based); CNCF |
+| [Docker Bench for Security](https://github.com/docker/docker-bench-security) | CIS Docker Benchmark checks |
+| [kube-hunter](https://github.com/aquasecurity/kube-hunter) | Cluster penetration-testing scanner (authorized use) |
+
+---
+
+## 📂 Folder Contents
+
+| File | Description | Status |
+|------|-------------|--------|
+| **[containers.md](./containers.md)** | Image and runtime security, container escape vectors, and hardening (Docker/OCI) | ✅ Complete |
+| **[kubernetes.md](./kubernetes.md)** | RBAC, Pod Security Standards, secrets, network policy, attack paths, and hardening | ✅ Complete |
+
+---
+
+## ⚠️ Security & Legal Disclaimer
+
+> [!CAUTION]
+> **Authorized use only.** The techniques here are for authorized assessment,
+> education, and defensive research. Test only clusters and images you own or have
+> **explicit written permission** to assess - and where the cluster runs on a cloud
+> provider, follow that provider's penetration-testing policy too. See
+> [LEGAL.md](../LEGAL.md).
+
+---
+
+## 📚 Resources
+
+- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) / [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker)
+- [NSA/CISA Kubernetes Hardening Guidance](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-152a)
+- [Kubernetes Security documentation](https://kubernetes.io/docs/concepts/security/)
+- [MITRE ATT&CK Containers Matrix](https://attack.mitre.org/matrices/enterprise/containers/)
+- [OWASP Kubernetes Top 10](https://owasp.org/www-project-kubernetes-top-ten/)
+
+---
+
+<div align="center">
+
+**⚠️ USE THIS REPO RESPONSIBLY AND LEGALLY ⚠️**
+
+**Repository**: [ULTIMATE CYBERSECURITY MASTER GUIDE](https://github.com/Pnwcomputers/ULTIMATE-CYBERSECURITY-MASTER-GUIDE)
+
+**Maintained by**: [Pacific Northwest Computers](https://github.com/Pnwcomputers)
+
+</div>
+
+---
+
+## Related Files
+- [containers.md](containers.md) - Container image & runtime security
+- [kubernetes.md](kubernetes.md) - Kubernetes security
+- [../Cloud/README.md](../Cloud/README.md) - Cloud security (managed K8s: EKS/AKS/GKE)
+- [../LEGAL.md](../LEGAL.md) - Legal notice and authorized-use terms

--- a/ContainerSecurity/containers.md
+++ b/ContainerSecurity/containers.md
@@ -1,0 +1,124 @@
+# 🐳 Container Image & Runtime Security
+
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized assessment,
+> education, and defensive research. Test only images and hosts you own or have
+> **explicit written permission** to assess. See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+Container (Docker/OCI) security reference - image and runtime risks, container
+escape vectors, and hardening.
+
+## ⚙️ Function
+Covers image security (base images, vulnerabilities, secrets, signing), runtime
+misconfigurations, the main **container escape** vectors, and a hardening baseline
+mapped to the CIS Docker Benchmark.
+
+## 🏆 Goal
+Let a reader assess a containerized workload for the common issues and recommend
+concrete hardening.
+
+## 📋 When to Use
+- Reviewing a container image or runtime configuration
+- Looking up container-escape vectors during an authorized test
+- Building a container hardening baseline
+
+---
+
+## 📋 Table of Contents
+
+- [Image Security](#image-security)
+- [Runtime Misconfigurations](#runtime-misconfigurations)
+- [Container Escape Vectors](#container-escape-vectors)
+- [Hardening](#hardening)
+- [Resources](#-resources)
+
+---
+
+## Image Security
+
+- **Vulnerabilities:** base images and packages carry known CVEs; scan every image
+  in CI and before deploy (`trivy image IMAGE`).
+- **Secrets in images:** credentials baked into layers or `ENV` persist in history -
+  never bake secrets; use build secrets / runtime injection; scan with Trivy/git-secrets.
+- **Untrusted base images:** prefer minimal, official, or distroless bases; pin by
+  digest, not floating tags.
+- **Provenance:** sign images and verify signatures (Cosign / Sigstore); enforce at
+  admission.
+
+```bash
+# Scan an image for vulnerabilities and misconfigurations (authorized)
+trivy image --severity HIGH,CRITICAL myorg/app:1.2.3
+```
+
+---
+
+## Runtime Misconfigurations
+
+The high-risk runtime settings (each is also an escape enabler):
+
+- **`--privileged`** - disables most isolation; near-equivalent to root on the host.
+- **Mounted Docker socket** (`-v /var/run/docker.sock:...`) - control of the socket
+  is control of the daemon, hence the host.
+- **Excessive capabilities** - especially `CAP_SYS_ADMIN`, `CAP_SYS_PTRACE`,
+  `CAP_NET_ADMIN`; drop all and add back only what is needed.
+- **`hostPath` / host namespaces** (`--pid=host`, `--net=host`) - break isolation.
+- **Running as root** inside the container; no read-only root filesystem.
+
+---
+
+## Container Escape Vectors
+
+For authorized testing, the classic escape checks:
+
+```bash
+# Am I in a container? What privileges?
+ls -la /.dockerenv 2>/dev/null; cat /proc/1/cgroup | grep -i docker
+capsh --print                       # enumerate capabilities
+mount | grep -i docker.sock         # mounted daemon socket?
+```
+
+Common escape paths:
+
+- **Privileged container** - mount the host filesystem or abuse cgroups to run code
+  on the node.
+- **Mounted `docker.sock`** - `docker -H unix:///var/run/docker.sock run --privileged
+  --pid=host ... nsenter` onto the host.
+- **`CAP_SYS_ADMIN`** - enables mounts and several escape techniques.
+- **Kernel/runtime vulnerabilities** - e.g. historical runc CVEs (keep the runtime patched).
+
+*(These are illustrative checks; only run them against systems you are authorized to test.)*
+
+---
+
+## Hardening
+
+- **Least privilege:** `--cap-drop=ALL` then add only what is needed; never
+  `--privileged`; run as a non-root `USER`; `--read-only` root FS with explicit
+  writable mounts.
+- **No host exposure:** don't mount `docker.sock`, host namespaces, or sensitive
+  `hostPath`s; use user namespaces where possible.
+- **Images:** minimal/distroless base, pinned by digest, scanned in CI, signed and
+  verified.
+- **Resources:** set CPU/memory limits to contain abuse.
+- **Runtime detection:** [Falco](https://github.com/falcosecurity/falco) for
+  anomalous syscalls; ship events to a [SIEM](../IncidentResponse/SIEM/README.md).
+- Benchmark with [Docker Bench for Security](https://github.com/docker/docker-bench-security)
+  against the [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker).
+
+---
+
+## 📚 Resources
+
+- [Trivy](https://github.com/aquasecurity/trivy) - image/IaC scanning
+- [CIS Docker Benchmark](https://www.cisecurity.org/benchmark/docker) / [Docker Bench](https://github.com/docker/docker-bench-security)
+- [Docker security documentation](https://docs.docker.com/engine/security/)
+- [Sigstore / Cosign](https://www.sigstore.dev/) - image signing & verification
+- [MITRE ATT&CK Containers](https://attack.mitre.org/matrices/enterprise/containers/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Container & Kubernetes Security section index
+- [kubernetes.md](kubernetes.md) - Kubernetes security
+- [../Cloud/README.md](../Cloud/README.md) - Cloud security

--- a/ContainerSecurity/kubernetes.md
+++ b/ContainerSecurity/kubernetes.md
@@ -1,0 +1,153 @@
+# ☸️ Kubernetes Security
+
+> [!CAUTION]
+> **Authorized use only.** The techniques below are for authorized assessment,
+> education, and defensive research. Test only clusters you own or have **explicit
+> written permission** to assess (and follow the cloud provider's pentest policy
+> for managed clusters). See [LEGAL.md](../LEGAL.md).
+
+## 🎯 Purpose
+Kubernetes security reference - the cluster attack surface, RBAC and Pod Security,
+common attack paths, and hardening.
+
+## ⚙️ Function
+Covers the K8s components and trust boundaries, RBAC, **Pod Security Standards**
+(the replacement for the removed PodSecurityPolicy), secrets, network policy,
+common attack paths, and a hardening baseline mapped to the CIS Kubernetes
+Benchmark and NSA/CISA guidance.
+
+## 🏆 Goal
+Let a reader assess a Kubernetes cluster methodically and recommend concrete
+hardening.
+
+## 📋 When to Use
+- Authorized assessment or hardening of a Kubernetes cluster
+- Looking up K8s attack paths (RBAC abuse, privileged pods, exposed API/kubelet)
+- Building a cluster hardening baseline
+
+---
+
+## 📋 Table of Contents
+
+- [Cluster Attack Surface](#cluster-attack-surface)
+- [RBAC](#rbac)
+- [Pod Security Standards (PSP is Removed)](#pod-security-standards-psp-is-removed)
+- [Secrets & Network Policy](#secrets--network-policy)
+- [Common Attack Paths](#common-attack-paths)
+- [Hardening & Detection](#hardening--detection)
+- [Resources](#-resources)
+
+---
+
+## Cluster Attack Surface
+
+- **API server** - the front door; exposed or weakly authenticated API servers are
+  a critical risk.
+- **etcd** - stores all cluster state (incl. secrets); must be encrypted and
+  access-restricted.
+- **kubelet** - the node agent; an exposed/anonymous kubelet API can allow command
+  execution in pods.
+- **Workloads** - over-privileged pods and service accounts.
+- **Supply chain** - images and admission (see [containers.md](containers.md)).
+
+---
+
+## RBAC
+
+Role-Based Access Control governs who can do what. Common problems:
+
+- **Over-permissive roles** - `cluster-admin` bindings, wildcard verbs/resources.
+- **Dangerous permissions** - `create pods` (+ a privileged pod), `create` on
+  `pods/exec`, `secrets get/list`, `escalate`/`bind` on roles, `impersonate`.
+- **Default service-account tokens** auto-mounted into pods that don't need them.
+
+```bash
+# Enumerate what the current identity can do (authorized)
+kubectl auth can-i --list
+kubectl auth can-i create pods
+```
+
+**Defend:** least-privilege roles; no wildcard `cluster-admin`; disable
+auto-mounting of service-account tokens where unused (`automountServiceAccountToken:
+false`); audit RBAC (kubescape / `kubectl-who-can`).
+
+---
+
+## Pod Security Standards (PSP is Removed)
+
+> [!IMPORTANT]
+> **PodSecurityPolicy (PSP) was deprecated in Kubernetes 1.21 and removed in 1.25.**
+> Guides that still tell you to configure PSPs are out of date. The built-in
+> replacement is **Pod Security Admission (PSA)**, which enforces the **Pod Security
+> Standards (PSS)**.
+
+The three Pod Security Standards levels:
+
+- **Privileged** - unrestricted (avoid for workloads).
+- **Baseline** - blocks known privilege escalations; a sensible minimum.
+- **Restricted** - hardened best practice (non-root, no privilege escalation,
+  dropped capabilities, seccomp).
+
+Apply per-namespace via labels (`pod-security.kubernetes.io/enforce: restricted`).
+For policy beyond PSA, use an admission controller like **OPA/Gatekeeper** or
+**Kyverno**.
+
+---
+
+## Secrets & Network Policy
+
+- **Secrets** are only base64-encoded at rest by default - enable **etcd encryption
+  at rest**, restrict `get/list secrets` via RBAC, and prefer an external secrets
+  manager (cloud KMS, Vault).
+- **Networking is flat by default** - any pod can reach any pod. Apply
+  **NetworkPolicies** (default-deny, then allow-list) to segment workloads and limit
+  lateral movement.
+
+---
+
+## Common Attack Paths
+
+For authorized testing, the recurring paths:
+
+- **Exposed API server / dashboard** without auth → cluster control.
+- **Anonymous or exposed kubelet** (`:10250`) → exec into pods.
+- **RBAC → pod creation** → schedule a privileged pod that mounts the host or reads
+  node credentials (a node/cloud-credential escalation).
+- **Readable secrets** → cloud credentials or app secrets → pivot.
+- **Container escape** from a workload to the node (see [containers.md](containers.md)).
+- Scanners: `kube-hunter` (pentest), `kubescape`, `kube-bench` (benchmark).
+
+---
+
+## Hardening & Detection
+
+- **Access:** strong API-server authn/authz; no anonymous auth; least-privilege
+  RBAC; protect the kubelet.
+- **Workloads:** enforce **Restricted** Pod Security where feasible; non-root,
+  read-only FS, dropped capabilities, seccomp; admission control (Gatekeeper/Kyverno).
+- **Data:** etcd encryption at rest; tight secret RBAC; external secret stores.
+- **Network:** default-deny NetworkPolicies; segment namespaces.
+- **Supply chain:** scan images (Trivy); require signed images at admission.
+- **Detection:** audit logging enabled and shipped to a
+  [SIEM](../IncidentResponse/SIEM/README.md); runtime detection with
+  [Falco](https://github.com/falcosecurity/falco).
+- **Benchmark:** [kube-bench](https://github.com/aquasecurity/kube-bench) against the
+  [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes); review
+  the [NSA/CISA Kubernetes Hardening Guidance](https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-152a).
+
+---
+
+## 📚 Resources
+
+- [Kubernetes Security docs](https://kubernetes.io/docs/concepts/security/) / [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes) / [kube-bench](https://github.com/aquasecurity/kube-bench)
+- [kubescape](https://github.com/kubescape/kubescape) / [Falco](https://github.com/falcosecurity/falco)
+- [OWASP Kubernetes Top 10](https://owasp.org/www-project-kubernetes-top-ten/)
+- [MITRE ATT&CK Containers](https://attack.mitre.org/matrices/enterprise/containers/)
+
+---
+
+## Related Files
+- [README.md](README.md) - Container & Kubernetes Security section index
+- [containers.md](containers.md) - container image & runtime security
+- [../Cloud/README.md](../Cloud/README.md) - managed Kubernetes (EKS/AKS/GKE) sits in the cloud section

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 | 🕸️ [Web Application Security](WebAppSecurity/) | OWASP Top 10 deep-dive and a full web app pentest methodology (recon, Burp workflow, injection/access-control/API testing) |
 | ☁️ [Cloud Security](Cloud/) | Shared-responsibility model, common misconfigurations, and per-provider attack surface & hardening for AWS, Azure/Entra ID, and GCP |
 | 📋 [Compliance & GRC](Compliance/) | Governance, risk & compliance - NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS Controls, and GDPR/HIPAA/CCPA with control mapping |
+| 📦 [Container & Kubernetes Security](ContainerSecurity/) | Image/runtime attack surface, container escape, and Kubernetes hardening (RBAC, Pod Security Standards, network policy) |
 | 🔴 [OPSEC](OPSEC/) | Operational security practices - anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 [Homelab Guides](Homelab/) | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🤖 [AI Cybersecurity Resources](AI/README.md) | Self-hosted AI agents (OpenClaw, AnythingLLM), LLM prompting for security, offline AI deployment, AI-powered security workflows |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -28,6 +28,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 - **Web App Pentester?** → [Web Application Security](WebAppSecurity/) ([OWASP Top 10](WebAppSecurity/owasp-top-10.md) + [Methodology](WebAppSecurity/methodology.md))
 - **Cloud Security?** → [Cloud Security](Cloud/) ([AWS](Cloud/aws.md) · [Azure/Entra ID](Cloud/azure.md) · [GCP](Cloud/gcp.md))
 - **Compliance / Auditor?** → [Compliance & GRC](Compliance/) ([Frameworks](Compliance/frameworks.md) · [Regulations](Compliance/regulations.md))
+- **Container / Kubernetes Security?** → [Container & Kubernetes Security](ContainerSecurity/) ([Containers](ContainerSecurity/containers.md) · [Kubernetes](ContainerSecurity/kubernetes.md))
 - **Hardware Hacker?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts II–III) + [Enhanced Master Guide](ENHANCED_MASTER_GUIDE.md) + [Firmware & Hardware Compatibility](firmware-hardware-compatibility.md)
 - **AI / LLM Security?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Part I) + [AI Resources](AI/README.md)
 - **SDR / RF / Space?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts V–VI) + [SDR](SDR/) + [SpaceSecurity](SpaceSecurity/)
@@ -93,6 +94,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 | 🕸️ **[Web Application Security](WebAppSecurity/)** | OWASP Top 10 deep-dive and web app pentest methodology (Burp workflow, injection/access-control/API testing) |
 | ☁️ **[Cloud Security](Cloud/)** | AWS, Azure/Entra ID, and GCP - shared responsibility, misconfigurations, attack surface, and hardening |
 | 📋 **[Compliance & GRC](Compliance/)** | Frameworks (NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS) and regulations (GDPR, HIPAA, CCPA) with control mapping |
+| 📦 **[Container & Kubernetes Security](ContainerSecurity/)** | Image/runtime security, container escape, and Kubernetes hardening (RBAC, Pod Security Standards) |
 | 🔴 **[OPSEC](OPSEC/)** | Operational security; anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 **[Homelab Guides](Homelab/)** | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🚨 **[Incident Response](IncidentResponse/)** | Blue Team operations; threat detection, log aggregation, artifact analysis, SIEM setup |


### PR DESCRIPTION
Coverage-gap section from the audit's Content Expansion Plan (~35 files referenced containers/K8s; scattered). New `ContainerSecurity/` section, house style.

## New content

| File | Covers |
|------|--------|
| `README.md` | Container threat model (image/runtime/host/orchestrator layers), tooling |
| `containers.md` | Image security, runtime misconfigurations, **container escape** vectors, hardening (CIS Docker Benchmark) |
| `kubernetes.md` | Cluster attack surface, **RBAC**, **Pod Security Standards**, secrets/etcd, network policy, attack paths, hardening (CIS K8s Benchmark, NSA/CISA) |

## Accuracy / currency

- **Key currency fix stated explicitly:** PodSecurityPolicy was **removed in K8s 1.25** and replaced by **Pod Security Admission / Pod Security Standards** — a very common stale point in older guides.
- Tool repos **verified active** (Trivy, kube-bench, kubescape, Falco, Docker Bench)
- NSA/CISA Kubernetes Hardening Guidance linked via the **stable CISA advisory page** (the direct PDF 403s to bots)

## Wiring & consistency

- F-09 authorization header on every doc (container escape / K8s attack paths are offensive/dual-use)
- Listed in `README.md` + `START_HERE.md`; added a **"Container / Kubernetes Security?"** role path
- `AUDIT_REPORT.md` G marked done

## Verification

- **All 81 links verified live** — 0 errors
- Anchors resolve; markdownlint clean

This leaves **Cryptography** as the last deliverable-G gap section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)