### PR TITLE
feat: add Cryptography section (final deliverable G gap)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -184,7 +184,7 @@ listed topic is **referenced in many files but lacks a dedicated section**.
 | ✅ Done | **Web Application Security** | ~47 files mentioned it; no dedicated section | Delivered: [`WebAppSecurity/`](./WebAppSecurity/README.md) (OWASP Top 10:2025 deep-dive + full methodology) |
 | ✅ Done | **Cloud Security** | ~42 files; only inside master guides | Delivered: [`Cloud/`](./Cloud/README.md) (AWS, Azure/Entra ID, GCP - attack surface + hardening) |
 | ✅ Done | **Container & Kubernetes Security** | ~35 files; scattered | Delivered: [`ContainerSecurity/`](./ContainerSecurity/README.md) (image/runtime, escape, K8s RBAC/Pod Security) |
-| Medium | **Cryptography** | ~24 files; only in cliff notes | `Documentation/cryptography.md` (primitives, TLS, hashing, PKI) |
+| ✅ Done | **Cryptography** | ~24 files; only in cliff notes | Delivered: [`Cryptography/`](./Cryptography/README.md) (algorithms, applied crypto, post-quantum) |
 | ✅ Done | **Compliance / GRC** | ~82 mentions; no structured home | Delivered: [`Compliance/`](./Compliance/README.md) (NIST CSF 2.0, ISO 27001:2022, SOC 2, PCI DSS 4.0.1, CIS v8; GDPR/HIPAA/CCPA) |
 | Low | **Detection Engineering** | ~27 files; partial via SIEM | extend `IncidentResponse/` (Sigma/YARA rule authoring) |
 

--- a/Cryptography/README.md
+++ b/Cryptography/README.md
@@ -1,0 +1,158 @@
+# 🔐 Cryptography
+
+<div align="center">
+
+**Practical cryptography reference - algorithms, applied use, and what to avoid**
+
+*Part of the [ULTIMATE CYBERSECURITY MASTER GUIDE](../README.md)*
+
+![Focus](https://img.shields.io/badge/Focus-Cryptography-blue?style=for-the-badge)
+![Standards](https://img.shields.io/badge/Standards-NIST_%7C_FIPS-orange?style=for-the-badge)
+![Type](https://img.shields.io/badge/Type-Reference-green?style=for-the-badge)
+
+</div>
+
+---
+
+## 🎯 Purpose
+Dedicated home for cryptography - which algorithms to use (and avoid), how to apply
+them correctly (TLS, password storage, key management), and where the field is
+heading (post-quantum).
+
+## ⚙️ Function
+Indexes the Cryptography section: fundamentals and a current-vs-deprecated summary
+(this file), an algorithm reference by primitive
+([algorithms.md](./algorithms.md)), and applied cryptography - TLS, password
+storage, key management, and common mistakes ([applied-crypto.md](./applied-crypto.md)).
+
+## 🏆 Goal
+Give practitioners a single reference for making correct, current cryptographic
+choices and recognizing the recurring mistakes - grounded in NIST guidance.
+
+## 📋 When to Use
+- Choosing an algorithm, key size, or mode for a design or review
+- Reviewing password storage, TLS config, or key management
+- Understanding the post-quantum transition and crypto-agility
+- Recognizing deprecated/broken primitives in existing code
+
+---
+
+## 📋 Table of Contents
+
+- [Overview](#-overview)
+- [The One Rule](#-the-one-rule)
+- [Current vs Deprecated (Quick Reference)](#-current-vs-deprecated-quick-reference)
+- [Post-Quantum Cryptography](#-post-quantum-cryptography)
+- [Folder Contents](#-folder-contents)
+- [Important Notice](#-important-notice)
+- [Resources](#-resources)
+
+---
+
+## 🎯 Overview
+
+Cryptography is referenced throughout this repository (TLS, hashing, password
+storage, VPNs, disk encryption) but had no dedicated home. This section
+consolidates it into fundamentals, an algorithm reference, and applied guidance -
+all aligned with current **NIST/FIPS** standards.
+
+The three primitive families:
+
+- **Symmetric** - one shared key for encryption (fast; AES, ChaCha20).
+- **Asymmetric** - public/private key pairs for key exchange and signatures
+  (RSA, ECC).
+- **Hashing** - one-way integrity fingerprints (SHA-2, SHA-3); with **KDFs** for
+  password storage (Argon2, bcrypt).
+
+---
+
+## 🛑 The One Rule
+
+> [!WARNING]
+> **Don't roll your own crypto.** Use well-reviewed, maintained libraries
+> (libsodium, the platform's TLS stack, `cryptography` for Python, Tink) and
+> vetted protocols. Almost every real-world cryptographic failure is a
+> *misuse* - wrong mode, reused nonce, hardcoded key, fast hash for passwords -
+> not a broken algorithm. Prefer **high-level, misuse-resistant** APIs.
+
+---
+
+## 📊 Current vs Deprecated (Quick Reference)
+
+| Use | ✅ Use | 🚫 Avoid / Deprecated |
+|-----|--------|------------------------|
+| Symmetric encryption | AES-256-GCM, ChaCha20-Poly1305 (AEAD) | DES, 3DES, RC4, AES-ECB |
+| Hashing (integrity) | SHA-256/384/512, SHA-3 | MD5, SHA-1 |
+| Password storage | Argon2id, scrypt, bcrypt, PBKDF2 | MD5/SHA "fast" hashes, unsalted hashes |
+| Asymmetric / key exchange | RSA ≥ 3072, ECC (P-256, Curve25519), ECDH | RSA ≤ 1024, static DH, custom curves |
+| Signatures | Ed25519, ECDSA (P-256), RSA-PSS | RSA ≤ 1024, DSA |
+| Transport | TLS 1.3 (1.2 acceptable) | TLS 1.0/1.1, SSLv3 |
+
+Deprecations follow **NIST SP 800-131A Rev 2** - e.g. 3DES is disallowed and SHA-1
+is being retired. Details in [algorithms.md](./algorithms.md).
+
+---
+
+## 🔮 Post-Quantum Cryptography
+
+A sufficiently large quantum computer would break RSA and ECC. The threat is
+already relevant via **"harvest now, decrypt later"** - adversaries capturing
+encrypted data today to decrypt once quantum is viable.
+
+**NIST finalized the first PQC standards in August 2024:**
+
+- **FIPS 203 - ML-KEM** (based on CRYSTALS-Kyber) - key encapsulation.
+- **FIPS 204 - ML-DSA** (based on CRYSTALS-Dilithium) - digital signatures.
+- **FIPS 205 - SLH-DSA** (based on SPHINCS+) - stateless hash-based signatures.
+
+**What to do now:** inventory where you use public-key crypto, build
+**crypto-agility** (the ability to swap algorithms), and plan migration - starting
+with long-lived secrets and hybrid (classical + PQC) key exchange.
+
+---
+
+## 📂 Folder Contents
+
+| File | Description | Status |
+|------|-------------|--------|
+| **[algorithms.md](./algorithms.md)** | Algorithm reference by primitive - symmetric, asymmetric, hashing, KDFs, and PQC, with key sizes and deprecations | ✅ Complete |
+| **[applied-crypto.md](./applied-crypto.md)** | Applied cryptography - TLS, password storage, key management, randomness, and common mistakes | ✅ Complete |
+
+---
+
+## ⚠️ Important Notice
+
+> [!IMPORTANT]
+> **Educational reference, not a substitute for a cryptographer.** For
+> high-assurance or novel designs, engage a specialist and prefer FIPS-validated
+> modules where required. Standards and recommended key sizes change - verify
+> against the current NIST publications before relying on specifics.
+
+---
+
+## 📚 Resources
+
+- [NIST Post-Quantum Cryptography](https://csrc.nist.gov/projects/post-quantum-cryptography)
+- [NIST SP 800-57 Part 1 (Key Management)](https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final)
+- [NIST SP 800-131A Rev 2 (Transitions)](https://csrc.nist.gov/pubs/sp/800/131/a/r2/final)
+- [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- [Cryptographic Right Answers (Latacora)](https://www.latacora.com/blog/2018/04/03/cryptographic-right-answers/)
+- [libsodium documentation](https://doc.libsodium.org/)
+
+---
+
+<div align="center">
+
+**Repository**: [ULTIMATE CYBERSECURITY MASTER GUIDE](https://github.com/Pnwcomputers/ULTIMATE-CYBERSECURITY-MASTER-GUIDE)
+
+**Maintained by**: [Pacific Northwest Computers](https://github.com/Pnwcomputers)
+
+</div>
+
+---
+
+## Related Files
+- [algorithms.md](algorithms.md) - algorithm reference by primitive
+- [applied-crypto.md](applied-crypto.md) - TLS, password storage, key management
+- [../Documentation/VPN.md](../Documentation/VPN.md) - applied transport encryption
+- [../GLOSSARY.md](../GLOSSARY.md) - acronyms (AEAD, KDF, PKI…)

--- a/Cryptography/algorithms.md
+++ b/Cryptography/algorithms.md
@@ -1,0 +1,139 @@
+# 🧮 Cryptographic Algorithm Reference
+
+> [!IMPORTANT]
+> Educational reference. Recommended key sizes and algorithm status change over
+> time - verify against current [NIST](https://csrc.nist.gov/) guidance for
+> high-assurance work, and use vetted libraries rather than implementing primitives.
+
+## 🎯 Purpose
+A quick, current reference to cryptographic algorithms by primitive - what to use,
+recommended parameters, and what is deprecated.
+
+## ⚙️ Function
+Covers symmetric ciphers, asymmetric algorithms, hash functions, key-derivation
+functions, and the new post-quantum standards, with key sizes and deprecation
+status per NIST SP 800-131A / SP 800-57.
+
+## 🏆 Goal
+Let a reader pick a correct algorithm and parameters for a given need, and
+recognize deprecated primitives in existing systems.
+
+## 📋 When to Use
+- Selecting an algorithm/key size for a design or code review
+- Checking whether a primitive in existing code is still acceptable
+
+---
+
+## 📋 Table of Contents
+
+- [Symmetric Encryption](#symmetric-encryption)
+- [Asymmetric Cryptography](#asymmetric-cryptography)
+- [Hash Functions](#hash-functions)
+- [Key Derivation Functions (Passwords)](#key-derivation-functions-passwords)
+- [Post-Quantum Algorithms](#post-quantum-algorithms)
+- [Resources](#-resources)
+
+---
+
+## Symmetric Encryption
+
+One shared secret key; fast; used for bulk data.
+
+| Algorithm | Status | Notes |
+|-----------|--------|-------|
+| **AES-256 / AES-128 (GCM)** | ✅ Recommended | AEAD (authenticated); GCM is the default choice |
+| **ChaCha20-Poly1305** | ✅ Recommended | AEAD; strong on platforms without AES hardware |
+| AES-CBC / AES-CTR | ⚠️ Use with care | Not authenticated - must add a MAC (encrypt-then-MAC); prefer AEAD |
+| AES-ECB | 🚫 Never | Leaks patterns (identical blocks → identical ciphertext) |
+| 3DES | 🚫 Disallowed | Deprecated by NIST SP 800-131A; small block size (Sweet32) |
+| DES / RC4 | 🚫 Broken | Do not use |
+
+**Prefer AEAD** (GCM, ChaCha20-Poly1305) - it provides confidentiality **and**
+integrity in one primitive. Never reuse a (key, nonce) pair.
+
+---
+
+## Asymmetric Cryptography
+
+Public/private key pairs; used for key exchange and signatures (slow - typically
+used to protect a symmetric key).
+
+| Algorithm | Status | Notes |
+|-----------|--------|-------|
+| **Curve25519 / X25519** | ✅ Recommended | Fast, safe ECDH key exchange |
+| **Ed25519** | ✅ Recommended | Fast signatures, misuse-resistant |
+| **ECDSA / ECDH (P-256, P-384)** | ✅ Acceptable | NIST curves; widely supported |
+| **RSA ≥ 3072** | ✅ Acceptable | 2048 acceptable near-term; use OAEP (enc) / PSS (sig) |
+| RSA ≤ 1024 | 🚫 Deprecated | Insufficient strength |
+| DSA | 🚫 Deprecated | Avoid; use EdDSA/ECDSA |
+| Static Diffie-Hellman | ⚠️ | Prefer ephemeral (DHE/ECDHE) for forward secrecy |
+
+Use **ephemeral** key exchange (ECDHE/X25519) for **forward secrecy**. Use OAEP
+padding for RSA encryption and PSS for RSA signatures - never textbook/PKCS#1 v1.5
+for new designs.
+
+---
+
+## Hash Functions
+
+One-way integrity fingerprints (not for passwords - see KDFs).
+
+| Algorithm | Status | Notes |
+|-----------|--------|-------|
+| **SHA-256 / SHA-384 / SHA-512** | ✅ Recommended | SHA-2 family; general-purpose integrity |
+| **SHA-3 / SHAKE** | ✅ Recommended | Different construction (sponge); good alternative |
+| **BLAKE2 / BLAKE3** | ✅ Good | Fast, modern (non-NIST) |
+| SHA-1 | 🚫 Deprecated | Collisions demonstrated (SHAttered); NIST retiring by 2030 |
+| MD5 | 🚫 Broken | Trivial collisions; never for security |
+
+For message authentication use **HMAC** (e.g. HMAC-SHA-256) or an AEAD cipher, not
+a bare hash.
+
+---
+
+## Key Derivation Functions (Passwords)
+
+Password hashing needs a **deliberately slow, salted** function - never a fast hash.
+
+| Function | Status | Notes |
+|----------|--------|-------|
+| **Argon2id** | ✅ Preferred | Memory-hard; winner of the Password Hashing Competition |
+| **scrypt** | ✅ Good | Memory-hard |
+| **bcrypt** | ✅ Acceptable | Long-established; ~72-byte input limit |
+| **PBKDF2** | ⚠️ Acceptable | FIPS-approved but not memory-hard; use a high iteration count |
+| MD5/SHA(-256) of a password | 🚫 Never | Fast hashes are trivially brute-forced even when salted |
+
+Always use a **unique random salt** per password; tune cost parameters to your
+hardware. See the [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html).
+
+---
+
+## Post-Quantum Algorithms
+
+NIST finalized the first standards in **August 2024**:
+
+| Standard | Algorithm | Purpose |
+|----------|-----------|---------|
+| **FIPS 203** | **ML-KEM** (CRYSTALS-Kyber) | Key encapsulation / key exchange |
+| **FIPS 204** | **ML-DSA** (CRYSTALS-Dilithium) | Digital signatures (primary) |
+| **FIPS 205** | **SLH-DSA** (SPHINCS+) | Hash-based signatures (conservative backup) |
+
+Adopt via **hybrid** schemes first (classical + PQC, e.g. X25519+ML-KEM) so a
+weakness in either still leaves the other. Prioritize long-lived data against
+"harvest now, decrypt later." See the
+[README post-quantum section](README.md#-post-quantum-cryptography).
+
+---
+
+## 📚 Resources
+
+- [NIST SP 800-131A Rev 2 (algorithm transitions)](https://csrc.nist.gov/pubs/sp/800/131/a/r2/final)
+- [NIST Post-Quantum Cryptography](https://csrc.nist.gov/projects/post-quantum-cryptography)
+- [FIPS 203 (ML-KEM)](https://csrc.nist.gov/pubs/fips/203/final) / [FIPS 204 (ML-DSA)](https://csrc.nist.gov/pubs/fips/204/final) / [FIPS 205 (SLH-DSA)](https://csrc.nist.gov/pubs/fips/205/final)
+- [OWASP Password Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html)
+
+---
+
+## Related Files
+- [README.md](README.md) - Cryptography section index
+- [applied-crypto.md](applied-crypto.md) - applying these algorithms correctly

--- a/Cryptography/applied-crypto.md
+++ b/Cryptography/applied-crypto.md
@@ -1,0 +1,122 @@
+# 🔧 Applied Cryptography
+
+> [!IMPORTANT]
+> Educational reference. Use vetted libraries and validated modules; the failures
+> below are common **misuses**, not algorithm weaknesses. See the
+> [section notice](README.md#-important-notice).
+
+## 🎯 Purpose
+How to apply cryptography correctly in practice - transport (TLS), password
+storage, key management, randomness - and the recurring mistakes to avoid.
+
+## ⚙️ Function
+Covers TLS configuration, password storage, key management and rotation, secure
+randomness, and a catalog of common cryptographic mistakes with fixes.
+
+## 🏆 Goal
+Let a reader implement or review the everyday uses of cryptography without falling
+into the well-known traps.
+
+## 📋 When to Use
+- Configuring or reviewing TLS
+- Implementing password storage or key management
+- Reviewing code for cryptographic misuse
+
+---
+
+## 📋 Table of Contents
+
+- [Transport Security (TLS)](#transport-security-tls)
+- [Password Storage](#password-storage)
+- [Key Management](#key-management)
+- [Randomness](#randomness)
+- [Common Mistakes](#common-mistakes)
+- [Resources](#-resources)
+
+---
+
+## Transport Security (TLS)
+
+- **Use TLS 1.3** (TLS 1.2 acceptable); disable TLS 1.0/1.1 and SSLv3
+  ([RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996)).
+- **Cipher suites:** AEAD only (AES-GCM, ChaCha20-Poly1305); enable **forward
+  secrecy** (ECDHE/X25519).
+- **Certificates:** 2048-bit RSA or ECDSA P-256; validate the full chain; automate
+  renewal (ACME/Let's Encrypt); enable **HSTS**.
+- **Test:** `testssl.sh`, Qualys SSL Labs, or `sslyze` to grade a configuration.
+
+```bash
+# Inspect a server's negotiated protocol/cipher
+openssl s_client -connect example.com:443 -tls1_3 </dev/null 2>/dev/null | grep -E "Protocol|Cipher"
+```
+
+---
+
+## Password Storage
+
+- Hash with a **memory-hard KDF** - **Argon2id** (preferred), scrypt, or bcrypt -
+  never a fast hash (see [algorithms.md](algorithms.md#key-derivation-functions-passwords)).
+- **Unique random salt per password** (the KDF handles this); tune cost to your hardware.
+- Consider a server-side **pepper** stored separately (e.g. in a KMS/HSM).
+- Check credentials against **breached-password** lists; support MFA.
+- Never log, email, or store plaintext passwords; never "encrypt" (reversible) them.
+
+---
+
+## Key Management
+
+Key management is where most real deployments fail (see NIST SP 800-57).
+
+- **Never hardcode keys** in source, images, or config committed to git; scan for
+  leaked secrets.
+- **Store keys in a KMS/HSM** (cloud KMS, HashiCorp Vault); grant least-privilege access.
+- **Rotate** keys on a schedule and after suspected compromise; support key
+  versioning so old data stays decryptable.
+- **Separate** key-encryption keys from data-encryption keys (envelope encryption).
+- **Limit blast radius:** per-tenant/per-purpose keys where feasible; log key usage.
+
+---
+
+## Randomness
+
+- Use a **cryptographically secure PRNG** - `/dev/urandom`, `getrandom(2)`,
+  `secrets` (Python), `crypto.randomBytes` (Node), `SecureRandom` (Java).
+- **Never** use `rand()`, `random`, `Math.random()`, or a time-seeded PRNG for keys,
+  tokens, IVs, salts, or session IDs.
+- Generate IVs/nonces per the cipher's rules (random or counter) and **never reuse**
+  a (key, nonce) pair with GCM/ChaCha20-Poly1305.
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Rolling your own crypto/protocol | Use vetted libraries (libsodium, Tink) and standard protocols |
+| ECB mode | Use an AEAD mode (GCM, ChaCha20-Poly1305) |
+| Reused IV/nonce with GCM | Unique nonce per encryption; rotate keys before exhaustion |
+| Encryption without authentication | Use AEAD, or encrypt-then-MAC (HMAC) |
+| Fast hash (MD5/SHA) for passwords | Argon2id/scrypt/bcrypt with per-password salt |
+| Hardcoded / committed keys | KMS/HSM; secret scanning in CI |
+| `Math.random()` for tokens | CSPRNG |
+| Textbook/PKCS#1 v1.5 RSA | OAEP for encryption, PSS for signatures |
+| Trusting unauthenticated ciphertext | Verify the MAC/tag before decrypting/using |
+| Ignoring the quantum horizon | Build crypto-agility; plan hybrid PQC migration |
+
+---
+
+## 📚 Resources
+
+- [OWASP Cryptographic Storage Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html)
+- [OWASP Transport Layer Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet.html)
+- [NIST SP 800-57 Part 1 (Key Management)](https://csrc.nist.gov/pubs/sp/800/57/pt1/r5/final)
+- [testssl.sh](https://testssl.sh/) - TLS configuration testing
+- [libsodium](https://doc.libsodium.org/) - misuse-resistant crypto library
+
+---
+
+## Related Files
+- [README.md](README.md) - Cryptography section index
+- [algorithms.md](algorithms.md) - algorithm reference by primitive
+- [../Documentation/VPN.md](../Documentation/VPN.md) - applied transport encryption
+- [../WebAppSecurity/owasp-top-10.md](../WebAppSecurity/owasp-top-10.md) - A04 Cryptographic Failures

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 | ☁️ [Cloud Security](Cloud/) | Shared-responsibility model, common misconfigurations, and per-provider attack surface & hardening for AWS, Azure/Entra ID, and GCP |
 | 📋 [Compliance & GRC](Compliance/) | Governance, risk & compliance - NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS Controls, and GDPR/HIPAA/CCPA with control mapping |
 | 📦 [Container & Kubernetes Security](ContainerSecurity/) | Image/runtime attack surface, container escape, and Kubernetes hardening (RBAC, Pod Security Standards, network policy) |
+| 🔐 [Cryptography](Cryptography/) | Practical crypto reference - current vs deprecated algorithms, applied use (TLS, password storage, key management), and post-quantum (FIPS 203/204/205) |
 | 🔴 [OPSEC](OPSEC/) | Operational security practices - anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 [Homelab Guides](Homelab/) | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🤖 [AI Cybersecurity Resources](AI/README.md) | Self-hosted AI agents (OpenClaw, AnythingLLM), LLM prompting for security, offline AI deployment, AI-powered security workflows |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -29,6 +29,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 - **Cloud Security?** → [Cloud Security](Cloud/) ([AWS](Cloud/aws.md) · [Azure/Entra ID](Cloud/azure.md) · [GCP](Cloud/gcp.md))
 - **Compliance / Auditor?** → [Compliance & GRC](Compliance/) ([Frameworks](Compliance/frameworks.md) · [Regulations](Compliance/regulations.md))
 - **Container / Kubernetes Security?** → [Container & Kubernetes Security](ContainerSecurity/) ([Containers](ContainerSecurity/containers.md) · [Kubernetes](ContainerSecurity/kubernetes.md))
+- **Cryptography?** → [Cryptography](Cryptography/) ([Algorithms](Cryptography/algorithms.md) · [Applied](Cryptography/applied-crypto.md))
 - **Hardware Hacker?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts II–III) + [Enhanced Master Guide](ENHANCED_MASTER_GUIDE.md) + [Firmware & Hardware Compatibility](firmware-hardware-compatibility.md)
 - **AI / LLM Security?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Part I) + [AI Resources](AI/README.md)
 - **SDR / RF / Space?** → [Specialized Topics Guide](SPECIALIZED_TOPICS_GUIDE.md) (Parts V–VI) + [SDR](SDR/) + [SpaceSecurity](SpaceSecurity/)
@@ -95,6 +96,7 @@ Routes readers by role and objective (beginner, pentester, OSCP candidate, blue 
 | ☁️ **[Cloud Security](Cloud/)** | AWS, Azure/Entra ID, and GCP - shared responsibility, misconfigurations, attack surface, and hardening |
 | 📋 **[Compliance & GRC](Compliance/)** | Frameworks (NIST CSF 2.0, ISO 27001, SOC 2, PCI DSS, CIS) and regulations (GDPR, HIPAA, CCPA) with control mapping |
 | 📦 **[Container & Kubernetes Security](ContainerSecurity/)** | Image/runtime security, container escape, and Kubernetes hardening (RBAC, Pod Security Standards) |
+| 🔐 **[Cryptography](Cryptography/)** | Current vs deprecated algorithms, applied crypto (TLS, password storage, key management), post-quantum |
 | 🔴 **[OPSEC](OPSEC/)** | Operational security; anonymity workflows, VM setup, personal rules for professionals |
 | 🏠 **[Homelab Guides](Homelab/)** | Building and maintaining safe, isolated labs for offensive and defensive practice |
 | 🚨 **[Incident Response](IncidentResponse/)** | Blue Team operations; threat detection, log aggregation, artifact analysis, SIEM setup |


### PR DESCRIPTION
The **last** coverage-gap section from the audit's Content Expansion Plan (~24 files referenced crypto; it lived only in the cliff notes). New `Cryptography/` section, house style.

## New content

| File | Covers |
|------|--------|
| `README.md` | Fundamentals, "don't roll your own crypto", **current-vs-deprecated** quick reference, post-quantum overview, key management |
| `algorithms.md` | Reference by primitive — symmetric, asymmetric, hashing, KDFs, **post-quantum** — with key sizes and deprecation status |
| `applied-crypto.md` | TLS, password storage, key management, randomness, and a **common-mistakes** catalog |

## Accuracy / currency

Verified against **NIST**:
- **Post-quantum:** FIPS 203 (ML-KEM), 204 (ML-DSA), 205 (SLH-DSA) — finalized **Aug 2024**; covers "harvest now, decrypt later" and crypto-agility
- **Deprecations** per SP 800-131A (3DES disallowed, SHA-1 retiring, MD5 broken)
- **Key management** per SP 800-57

## Framing

Reference/defensive content, so a **"not a cryptographer / use vetted libraries"** notice rather than the offensive F-09 header. The recurring theme: real failures are *misuse* (ECB, nonce reuse, fast hashes for passwords, hardcoded keys), not broken algorithms.

## Wiring & verification

- Listed in `README.md` + `START_HERE.md`; added a **"Cryptography?"** role path
- `AUDIT_REPORT.md` G marked done
- **All 63 links verified live**; anchors resolve; markdownlint clean

## 🎉 This completes deliverable G

All five expansion-plan gap sections are now delivered: **Web App, Cloud, Compliance/GRC, Containers/K8s, and Cryptography.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)