### PR TITLE
docs: cross-link microcontroller guide + fix broken section-README nav paths

### DIFF
--- a/Cloud/README.md
+++ b/Cloud/README.md
@@ -166,4 +166,4 @@ Provider-native: **AWS** IAM Access Analyzer / GuardDuty / Security Hub,
 - [../LEGAL.md](../LEGAL.md) - Legal notice and authorized-use terms
 
 ---
-| [⬅️ Back to Master Index](README.md) |
+| [⬅️ Back to Master Index](../README.md) |

--- a/Compliance/README.md
+++ b/Compliance/README.md
@@ -160,4 +160,4 @@ cross-framework crosswalks to accelerate this.
 - [../Checklists/README.md](../Checklists/README.md) - operational checklists that implement controls
 
 ---
-| [⬅️ Back to Master Index](README.md) |
+| [⬅️ Back to Master Index](../README.md) |

--- a/ContainerSecurity/README.md
+++ b/ContainerSecurity/README.md
@@ -141,4 +141,4 @@ weaker than a VM - a misconfiguration or kernel vulnerability can lead to escape
 - [../LEGAL.md](../LEGAL.md) - Legal notice and authorized-use terms
 
 ---
-[⬅️ Back to Master Index](README.md) | [🎯 Role Navigation](START_HERE.md) | [Legal Notice](LEGAL.md)
+[⬅️ Back to Master Index](../README.md) | [🎯 Role Navigation](../START_HERE.md) | [Legal Notice](../LEGAL.md)

--- a/Cryptography/README.md
+++ b/Cryptography/README.md
@@ -158,4 +158,4 @@ with long-lived secrets and hybrid (classical + PQC) key exchange.
 - [../GLOSSARY.md](../GLOSSARY.md) - acronyms (AEAD, KDF, PKI…)
 
 ---
-[⬅️ Back to Master Index](README.md) |
+[⬅️ Back to Master Index](../README.md) |

--- a/Documentation/microcontroller_wifi_testing.md
+++ b/Documentation/microcontroller_wifi_testing.md
@@ -369,4 +369,18 @@ The goal is not simply to generate wireless activity. The goal is to create a re
 - [MikroTik RouterOS Packet Sniffer](https://help.mikrotik.com/docs/spaces/ROS/pages/8323088/Packet+Sniffer)
 - [MikroTik RouterOS Wireless Interface Documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/8978446/Wireless+Interface)
 
+---
+
+## Related Files (in this repo)
+
+- [WiFiMarauder_Guide.md](WiFiMarauder_Guide.md) / [WifiMarauder_CheatSheet.md](WifiMarauder_CheatSheet.md) - ESP32 Marauder reference and commands
+- [pwnagotchi_cheatsheet.md](pwnagotchi_cheatsheet.md) - Pwnagotchi setup and command reference
+- [evil_m5.md](evil_m5.md) / [bruce_firmware.md](bruce_firmware.md) - M5Stack / Cardputer firmware workflows
+- [flipper_zero_guide.md](flipper_zero_guide.md) - Flipper Zero (Sub-GHz, Wi-Fi Dev Board)
+- [wireshark.md](wireshark.md) - Wireshark filters for analyzing the captured traffic
+- [hcxtoolshashcat.md](hcxtoolshashcat.md) - converting captures and auditing handshake strength
+- [../Homelab/workflows/self-hosted_network_attacks.md](../Homelab/workflows/self-hosted_network_attacks.md) - full self-hosted wireless lab assessment playbook
+- [../SDR/README.md](../SDR/README.md) - RF / Sub-GHz context for the CC1101 role
+- [../LEGAL.md](../LEGAL.md) - legal notice and authorized-use terms
+
 *Last Updated: 08-03-2026*


### PR DESCRIPTION
Two related documentation fixes — one is an audit follow-up, the other unbreaks `main`'s CI.

## 1. `microcontroller_wifi_testing.md` — audit result

You rewrote this file on `main` into a comprehensive version. I audited **that** version rather than imposing my earlier parallel rewrite (closed as #69):

- **Facts:** sound — and notably careful (correctly noting Pwnagotchi isn't purely passive, that Flipper's Sub-GHz radio doesn't provide Wi-Fi, WPA3-SAE differences, 2.4 GHz-only limits).
- **Links:** all 14 external links verified live.
- **Safety:** the "Security and Ethical Considerations" section thoroughly covers deauth/beacon/Sub-GHz legality and authorization — strong.
- **The one gap:** it had **zero internal repo cross-links**. Added a "Related Files (in this repo)" section linking the Marauder/Pwnagotchi/Flipper/Wireshark/hcxtools guides, the Homelab wireless playbook, SDR, and `LEGAL.md`. **Your rewrite's content is unchanged.**

## 2. Broken section-README nav footers (was failing `main` CI)

The navigation footers added to `Cloud/`, `Compliance/`, `ContainerSecurity/`, and `Cryptography/` README.md used **root-relative paths from a subdirectory**:

- `](README.md)` → resolved to the file *itself*, not the master index
- `](START_HERE.md)` / `](LEGAL.md)` in ContainerSecurity → **hard 404s** (`ContainerSecurity/START_HERE.md` doesn't exist), failing the offline link-check on `main`

Corrected all four to `../`.

## Verification

- Full-repo offline anchor/link check: **0 errors** (was 2)
- markdownlint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)