### PR TITLE
feat: add "Navigate by Area" grouped index to README (deliverable F, Phase 1)

### DIFF
--- a/AUDIT_REPORT.md
+++ b/AUDIT_REPORT.md
@@ -162,9 +162,9 @@ logically. A higher-effort version physically relocates them into folders.
 
 ### Recommended approach
 
-- **Phase 1 (safe, recommended):** implement the grouping as an **index table**
-  in `README.md`/`START_HERE.md` only. Zero file moves, zero broken links,
-  immediate navigation benefit.
+- **Phase 1 (safe, recommended):** ✅ **Done** - implemented as the
+  [Navigate by Area](./README.md#-navigate-by-area) grouped index in `README.md`
+  (zero file moves, zero broken links). Complements `START_HERE.md`'s by-role routing.
 - **Phase 2 (owner-gated):** *if* physical reorganization is desired, move one
   group at a time, each as its own PR, updating every inbound link and anchor and
   re-running the CI anchor guard. Given F-07 was deferred, treat this as optional.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ Your complete navigation guide with quick paths for every role and purpose (Red 
 
 ---
 
+## 🧭 Navigate by Area
+
+A grouped map of the whole repository. Prefer routing by **role/goal**? Use
+[START_HERE.md](START_HERE.md). Want the full flat catalog? See
+[Supporting Guides & Reference](#-supporting-guides--reference-material) below.
+
+| Area | Start here | Also in this area |
+|------|-----------|-------------------|
+| 🚀 **Start & Master Guides** | [START_HERE.md](START_HERE.md) | [Ultimate](ultimate_cybersecurity_master_guide.md) · [Enhanced](ENHANCED_MASTER_GUIDE.md) · [Specialized Topics](SPECIALIZED_TOPICS_GUIDE.md) · [Cliff Notes](cybersecurity_cliff_notes.md) |
+| 🗡️ **Offensive Security** | [Tradecraft/](Tradecraft/) | [Advanced Techniques](advanced_techniques_supplement.md) · [Part 2](advanced_techniques_part2.md) · [PlayBooks/](PlayBooks/) · [Checklists/](Checklists/) |
+| 🕸️ **App, Cloud & Container** | [WebAppSecurity/](WebAppSecurity/) | [Cloud/](Cloud/) · [ContainerSecurity/](ContainerSecurity/) |
+| 🛡️ **Defensive & Incident Response** | [IncidentResponse/](IncidentResponse/) | [SIEM](IncidentResponse/SIEM/) · [Digital Forensics](IncidentResponse/Digital-Forensics/) · [Homelab/](Homelab/) |
+| 🔍 **OSINT & Recon** | [OSINT/](OSINT/) | [Tools Catalog](OSINT/OSINT_TOOLS_CATALOG.md) · [Investigator Playbook](OSINT/Playbook/README.md) |
+| 📡 **Specialized & Hardware** | [SPECIALIZED_TOPICS_GUIDE.md](SPECIALIZED_TOPICS_GUIDE.md) | [AI/](AI/) · [SDR/](SDR/) · [HardwareHacking/](HardwareHacking/) · [SpaceSecurity/](SpaceSecurity/) · [Mobile/](Mobile/) · [uConsole/](uConsole/) |
+| 🔐 **Governance, Crypto & Reference** | [Compliance/](Compliance/) | [Cryptography/](Cryptography/) · [Documentation/](Documentation/) · [GLOSSARY.md](GLOSSARY.md) · [OPSEC/](OPSEC/) |
+| ⚖️ **Legal & Contributing** | [LEGAL.md](LEGAL.md) | [STYLE_GUIDE.md](STYLE_GUIDE.md) · [Contributing](.github/CONTRIBUTING.md) |
+
+---
+
 ## 📚 PRIMARY MASTER GUIDES
 
 | Guide | Description |


### PR DESCRIPTION
Implements the audit's **navigation-layer index** — Phase 1 of the Information Architecture proposal (deliverable F). This is the *safe* IA improvement: **no files move**, it's purely an added orientation map.

## What it does

Adds a grouped **"🧭 Navigate by Area"** table near the top of `README.md` that maps the whole repository into logical, mutually-exclusive groups:

- 🚀 Start & Master Guides
- 🗡️ Offensive Security
- 🕸️ App, Cloud & Container
- 🛡️ Defensive & Incident Response
- 🔍 OSINT & Recon
- 📡 Specialized & Hardware
- 🔐 Governance, Crypto & Reference
- ⚖️ Legal & Contributing

So a newcomer can orient **by area** in one glance instead of scanning a flat list of ~25 sections. It explicitly points to `START_HERE.md` for by-**role** routing and to the full flat catalog below — the three complement each other.

## Why this and not a folder reorg

The audit's IA proposal had two phases. **Phase 2** (physically moving root guides into folders) is owner-gated and risky — it would re-break inbound links and anchors. **Phase 1** (this) gets most of the navigation benefit at zero risk. Given F-07 (doc splitting) was deferred, Phase 1 is the right call.

## Verification

- All group links + the section anchor resolve — offline `--include-fragments`: **0 errors** repo-wide
- markdownlint clean
- Marked done in `AUDIT_REPORT.md` § F

🤖 Generated with [Claude Code](https://claude.com/claude-code)